### PR TITLE
Layout improvements

### DIFF
--- a/src/new-dash/activity-monitor/components/activity-monitor.css
+++ b/src/new-dash/activity-monitor/components/activity-monitor.css
@@ -1,0 +1,5 @@
+.activity-monitor .ms-Spinner-circle {
+    border-color: white;
+    border-top-color: black;
+    margin: 0;
+}

--- a/src/new-dash/activity-monitor/components/activity-monitor.js
+++ b/src/new-dash/activity-monitor/components/activity-monitor.js
@@ -2,11 +2,12 @@ import React from "react"
 import { connect } from "react-redux"
 import { Spinner } from "office-ui-fabric-react"
 
+import "./activity-monitor.css"
 import { isBusy } from "../"
 
 const ActivityMonitor = (props) => {
   if (!props.isBusy) return null
-  return <Spinner label="Processing request..." />
+  return <Spinner className="activity-monitor" />
 }
 
 export default connect(

--- a/src/new-dash/app.css
+++ b/src/new-dash/app.css
@@ -1,1 +1,24 @@
-.padding-05 { padding: 0.5em; }
+.header {
+    padding: 0.5em;
+}
+
+.header ul {
+    float: right;
+}
+
+.header ul li {
+    display: inline-block;
+    list-style: none;
+    padding: 0.5em;
+    vertical-align: middle;
+}
+
+.header a {
+    color: white;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.header a:hover {
+    color: #0078d7;
+}

--- a/src/new-dash/app.js
+++ b/src/new-dash/app.js
@@ -41,10 +41,18 @@ class Container extends Component {
   }
 
   render() {
-    return <div className="ms-Grid">
-        <div className="ms-Grid-row ms-bgColor-black">
-          <div className="ms-Grid-col ms-u-sm7 ms-u-md5 ms-u-lg2 padding-05">
+    return <div className="ms-Grid ms-Fabric ms-font-m">
+        <div className="ms-Grid-row header">
+          <div className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2 padding-05">
             <Link to="/"><img src={logo} alt="logo" /></Link>
+          </div>
+          <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10 padding-05">
+            <ul>
+              <li><ActivityMonitor /></li>
+              <li><a href="http://fauna.com/tutorials" target="_blank">Tutorials</a></li>
+              <li><a href="http://fauna.com/documentation" target="_blank">Documentation</a></li>
+              <li><i className="ms-Icon ms-Icon--Contact" aria-hidden="true"></i></li>
+            </ul>
           </div>
         </div>
         <div className="ms-Grid-row">
@@ -52,7 +60,6 @@ class Container extends Component {
             <NavTree />
           </div>
           <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg8">
-            <ActivityMonitor />
             <NotificationBar />
             {React.Children.map(this.props.children,
               child => React.cloneElement(child, { faunaClient: this.rootClient })

--- a/src/new-dash/notifications/components/notification-bar.css
+++ b/src/new-dash/notifications/components/notification-bar.css
@@ -1,0 +1,9 @@
+.notification-bar ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.notification-bar li {
+    padding: 2px 0;
+}

--- a/src/new-dash/notifications/components/notification-bar.js
+++ b/src/new-dash/notifications/components/notification-bar.js
@@ -2,6 +2,7 @@ import React from "react"
 import { connect } from "react-redux"
 import { MessageBar, MessageBarType } from "office-ui-fabric-react"
 
+import "./notification-bar.css"
 import { NotificationType } from "../"
 
 const messageBarTypeFor = (notificationType) => {
@@ -13,16 +14,18 @@ const messageBarTypeFor = (notificationType) => {
 }
 
 const NotificationBar = (props) => {
-  return <ul>{
-    props.notifications.map((notification, index) => (
-      <li key={index}>
-        <MessageBar
-          messageBarType={messageBarTypeFor(notification.type)}>
-          {notification.message}
-        </MessageBar>
-      </li>
-    ))
-  }</ul>
+  return <div className="notification-bar">
+      <ul>{
+      props.notifications.map((notification, index) => (
+        <li key={index} className="ms-u-fadeIn100">
+          <MessageBar
+            messageBarType={messageBarTypeFor(notification.type)}>
+            {notification.message}
+          </MessageBar>
+        </li>
+      ))
+    }</ul>
+  </div>
 }
 
 export default connect(

--- a/src/new-dash/schema/components/nav-db-tree.js
+++ b/src/new-dash/schema/components/nav-db-tree.js
@@ -2,12 +2,7 @@ import React from "react"
 import Immutable from "immutable"
 import { connect } from "react-redux"
 import { browserHistory } from "react-router"
-import { Nav } from 'office-ui-fabric-react';
-
-const onClick = (url) => (e) => {
-  e.preventDefault()
-  browserHistory.push(url)
-}
+import { Nav, css } from "office-ui-fabric-react";
 
 const databaseLinks = (schema, dbUrl = "") => {
   const databaseTree = (db) => {
@@ -19,7 +14,6 @@ const databaseLinks = (schema, dbUrl = "") => {
       url,
       key: url,
       isExpanded: true,
-      onClick: onClick(url),
       links: databaseLinks(db, url)
     }
   }
@@ -31,17 +25,40 @@ const databaseLinks = (schema, dbUrl = "") => {
     .toJS()
 }
 
+const onClick = (e, link) => {
+  e.preventDefault()
+  browserHistory.push(link.url)
+}
+
 const NavDBTree = (props) => {
   const links = [{
-    links: [{
-      name: "Databases",
-      isExpanded: true,
-      onClick: onClick("/"),
-      links: databaseLinks(props.schema)
-    }]
+    name: "Databases",
+    isExpanded: true,
+    links: databaseLinks(props.schema)
   }]
 
-  return <Nav groups={links} />
+  return <Flav groups={links} onLinkClick={onClick} />
+}
+
+// Custom nav tree to add chevron icon to all sub databases
+class Flav extends Nav {
+  _renderCompositeLink(link, linkIndex, nestingLevel) {
+    const key = link.key || linkIndex
+    const isLinkSelected = key === this.state.selectedKey
+
+    return <div key={key}
+        className={css("ms-Nav-compositeLink", {"is-expanded": link.isExpanded, "is-selected": isLinkSelected })}>
+          {(link.links && link.links.length > 0 ?
+            <button
+              className="ms-Nav-chevronButton ms-Nav-chevronButton--link"
+              onClick={this._onLinkExpandClicked.bind(this, link)}
+              title={(link.isExpanded ? this.props.expandedStateText : this.props.collapsedStateText)}>
+              <i className="ms-Nav-chevron ms-Icon ms-Icon--ChevronDown"></i>
+            </button> : null
+          )}
+        {!!link.onClick ? this._renderButtonLink(link, linkIndex) : this._renderAnchorLink(link, linkIndex, nestingLevel)}
+      </div>
+  }
 }
 
 export default connect(

--- a/src/new-dash/schema/components/nav-schema.js
+++ b/src/new-dash/schema/components/nav-schema.js
@@ -10,29 +10,26 @@ const asLinks = (items) => {
   return items.map(name => {
     return {
       name: name,
-      key: name,
-      onClick: onClick
+      key: name
     }
   }).toJS()
 }
 
 const NavSchema = (props) => {
-  const links = [{
-    links: [
-      {
-        name: "Classes",
-        links: asLinks(props.classes),
-        isExpanded: true
-      },
-      {
-        name: "Indexes",
-        links: asLinks(props.indexes),
-        isExpanded: true
-      }
-    ]
-  }]
+  const links = [
+    {
+      name: "Classes",
+      links: asLinks(props.classes),
+      isExpanded: true
+    },
+    {
+      name: "Indexes",
+      links: asLinks(props.indexes),
+      isExpanded: true
+    }
+  ]
 
-  return <Nav groups={links} />
+  return <Nav groups={links} onLinkClick={onClick} />
 }
 
 export default connect(

--- a/src/new-dash/schema/components/nav-tree.js
+++ b/src/new-dash/schema/components/nav-tree.js
@@ -6,10 +6,10 @@ import NavSchema from "./nav-schema.js"
 
 const NavTree = (props) => {
   return <div className="ms-Grid-row">
-      <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg6">
+      <div className="ms-Grid-col ms-u-sm12 ms-u-xl6">
         <NavDBTree />
       </div>
-      <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg6">
+      <div className="ms-Grid-col ms-u-sm12 ms-u-xl6">
         <NavSchema />
       </div>
     </div>


### PR DESCRIPTION
Makes the new schema tree a little better:

![image](https://cloud.githubusercontent.com/assets/813042/22564666/7be33050-e96c-11e6-9530-35857ff33f5f.png)

With activity monitor:
![image](https://cloud.githubusercontent.com/assets/813042/22565092/1142e3d8-e96e-11e6-8adf-d651e2c685d1.png)

With notifications:
![image](https://cloud.githubusercontent.com/assets/813042/22565048/f2aed3b4-e96d-11e6-8b65-804408de62e8.png)

Small screens:
![image](https://cloud.githubusercontent.com/assets/813042/22565131/315adaa4-e96e-11e6-9cb8-edf26a5c9c50.png)

Mostly copy and past from what we've delivered already with some minor adjustments for tablet and phones.