### PR TITLE
Minor fix: do not render column if there is no value to render

### DIFF
--- a/src/new-dash/dataset/components/query-result.js
+++ b/src/new-dash/dataset/components/query-result.js
@@ -104,6 +104,8 @@ export default class QueryResult extends Component {
 
   renderItemColumn(item, index, column) {
     const value = item[column.key || index]
+    if (!value) return null
+
     const specialItem = renderSpecialType(item)
     const specialValue = renderSpecialType(value)
     const result = specialItem || specialValue || value


### PR DESCRIPTION
So this query works:

```
[
  q.Ref("databases"),
  "test"
]
```