### PR TITLE
Paginate schema tree

### DIFF
--- a/src/new-dash/schema/__tests__/derived-data.js
+++ b/src/new-dash/schema/__tests__/derived-data.js
@@ -13,6 +13,7 @@ const schemaTree = Immutable.fromJS({
     name: "/"
   },
   databases: {
+    cursor: "fake cursor",
     byName: {
       "my-app": {
         info: {
@@ -199,14 +200,23 @@ describe("databaseTree", () => {
     expect(databaseTree(state).toJS()).toEqual({
       url: "/db/databases",
       name: "/",
+      path: [],
+      hasMore: true,
+      cursor: "fake cursor",
       databases: [
         {
           url: "/db/my-app/databases",
           name: "my-app",
+          path: ["my-app"],
+          hasMore: false,
+          cursor: null,
           databases: [
             {
               url: "/db/my-app/my-blog/databases",
               name: "my-blog",
+              path: ["my-app", "my-blog"],
+              hasMore: false,
+              cursor: null,
               databases: []
             }
           ]

--- a/src/new-dash/schema/__tests__/schema-tree.js
+++ b/src/new-dash/schema/__tests__/schema-tree.js
@@ -3,6 +3,7 @@ import { query as q } from "faunadb"
 
 import {
   loadSchemaTree,
+  loadMoreDatabases,
   createDatabase,
   deleteDatabase,
   createClass,
@@ -219,6 +220,33 @@ describe("Given a schema tree store", () => {
           rootDatabase.schemaTree
           .setIn(["databases", "byName", "my-app"], subDatabase.schemaTree)
           .toJS()
+        )
+      })
+    })
+
+    it("should be able to load a more databases", () => {
+      faunaClient.queryWithPrivilegesOrElse.mockReturnValue(
+        Promise.resolve({
+          databases: {
+            data: [{
+              name: "another-db"
+            }]
+          }
+        })
+      )
+
+      return store.dispatch(loadMoreDatabases(faunaClient, [], "database-cursor")).then(() => {
+        expect(schema).toEqual(
+          rootDatabase.schemaTree
+            .setIn(["databases", "byName", "another-db"], {
+              info: { name: "another-db" },
+              loaded: false,
+              databases: {},
+              classes: {},
+              indexes: {}
+            })
+            .setIn(["databases", "cursor"], null)
+            .toJS()
         )
       })
     })


### PR DESCRIPTION
Establish a pagination strategy for the schema tree according to the follow rules:
- Always load all classes and indexes for the selected database
- When there are more databases than the default pagination size, display a "Load more" button at the navigation tree.

![image](https://cloud.githubusercontent.com/assets/813042/23263979/9915748c-f9be-11e6-96ce-96fef80c1391.png)
