### PR TITLE
Lazy load database tree as the user navigates through it

### DIFF
--- a/src/new-dash/app.js
+++ b/src/new-dash/app.js
@@ -25,13 +25,6 @@ import {
 
 class Container extends Component {
 
-  componentDidMount() {
-    this.updateSelectedResource(
-      this.props.faunaClient,
-      this.props.params.splat
-    )
-  }
-
   componentWillReceiveProps(next) {
     const oldParams = Immutable.Map(this.props.params)
     const newParams = Immutable.Map(next.params)

--- a/src/new-dash/app.js
+++ b/src/new-dash/app.js
@@ -35,10 +35,6 @@ class Container extends Component {
         next.params
       )
     }
-
-    if (this.props.faunaClient !== next.faunaClient) {
-      this.loadRootDatabase(next.faunaClient)
-    }
   }
 
   updateSelectedResource(client, params) {
@@ -53,17 +49,6 @@ class Container extends Component {
             return dispatch(loadSchemaTree(client, selected.get("database")))
           }
         )
-      )
-    )
-  }
-
-  loadRootDatabase(client) {
-    if (!client) return
-
-    this.props.dispatch(
-      watchForError(
-        "Unexpected error while loading root database",
-        loadSchemaTree(client)
       )
     )
   }

--- a/src/new-dash/app.js
+++ b/src/new-dash/app.js
@@ -35,6 +35,10 @@ class Container extends Component {
         next.params
       )
     }
+
+    if (this.props.faunaClient !== next.faunaClient) {
+      this.loadRootDatabase(next.faunaClient)
+    }
   }
 
   updateSelectedResource(client, params) {
@@ -49,6 +53,17 @@ class Container extends Component {
             return dispatch(loadSchemaTree(client, selected.get("database")))
           }
         )
+      )
+    )
+  }
+
+  loadRootDatabase(client) {
+    if (!client) return
+
+    this.props.dispatch(
+      watchForError(
+        "Unexpected error while loading root database",
+        loadSchemaTree(client)
       )
     )
   }

--- a/src/new-dash/schema/__tests__/schema-tree.js
+++ b/src/new-dash/schema/__tests__/schema-tree.js
@@ -13,334 +13,361 @@ import {
   reduceSchemaTree
 } from "../"
 
-import { KeyType } from "../../persistence/faunadb-wrapper"
+const serverResponseByDatabasePathAndKeyType = Immutable.fromJS({
+  "": {
+    "admin": { databases: { data: [{ name: "production", ref: q.Ref("databases/production") }] } },
+    "server": { classes: { data: [] }, indexes: { data: [] } }
+  },
+  "production": {
+    "admin": {
+      databases: {
+        data: [
+          { name: "site", ref: q.Ref("databases/site") },
+          { name: "blog", ref: q.Ref("databases/blog") }
+        ]
+      }
+    },
+    "server": { classes: { data: [] }, indexes: { data: [] } }
+  },
+  "production/site": {
+    "admin": { databases: { data: [ { name: "tenants", ref: q.Ref("databases/tenants") } ] } },
+    "server": {
+      classes: { data: [{ name: "users", ref: q.Ref("classes/users") }] },
+      indexes: { data: [{ name: "all_users", ref: q.Ref("indexes/all_users") }] }
+    }
+  },
+  "production/site/tenants": {
+    "admin": { databases: { data: [{ name: "user123", ref: q.Ref("databases/user123") }] } },
+    "server": { classes: { data: [] }, indexes: { data: [] } }
+  },
+  "production/site/tenants/user123": {
+    "admin": { databases: { data: [] } },
+    "server": { classes: { data: [] }, indexes: { data: [] } }
+  },
+  "production/blog": {
+    "admin": { databases: { data: [] } },
+    "server": {
+      classes: { data: [{ name: "posts", ref: q.Ref("classes/posts") }] },
+      indexes: { data: [{ name: "all_posts", ref: q.Ref("indexes/all_posts") }] }
+    }
+  }
+})
 
-const rootDatabase = {
-  adminKeyResponse: {
-    databases: {
-      data: [{
-        name: "my-app",
-        ref: q.Ref("databases/my-app"),
-        ts: 123
-      }],
-      after: "database-cursor"
-    }
-  },
-  serverKeyResponse: {
-    classes: {
-      data: [{
-        name: "people",
-        ref: q.Ref("classes/people"),
-        ts: 11
-      }],
-      cursor: "class-cursor"
-    },
-    indexes: {
-      data: [{
-        name: "all_people",
-        ref: q.Ref("indexes/all_people"),
-        ts: 22
-      }],
-      cursor: "index-cursor"
-    }
-  },
-  schemaTree: Immutable.fromJS({
-    info: {
-      name: "/",
-      schemaLoaded: true,
-      databasesLoaded: true
-    },
-    databases: {
-      byName: {
-        "my-app": {
-          info: {
-            name: "my-app",
-            ref: q.Ref("databases/my-app"),
-            ts: 123
-          },
-          databases: {},
-          classes: {},
-          indexes: {}
-        }
-      },
-      cursor: "database-cursor"
-    },
-    classes: {
-      byName: {
-        "people": {
-          name: "people",
-          ref: q.Ref("classes/people"),
-          ts: 11
-        }
-      },
-      cursor: null
-    },
-    indexes: {
-      byName: {
-        "all_people": {
-          name: "all_people",
-          ref: q.Ref("indexes/all_people"),
-          ts: 22
-        }
-      },
-      cursor: null
-    }
-  })
-}
+const mockFaunaClient = () => {
+  const client = {
+    query: jest.fn(),
+    queryWithPrivilegesOrElse: jest.fn()
+  }
 
-const subDatabase = {
-  serverKeyResponse: {
-    classes: {
-      data: [{
-        name: "users",
-        ref: q.Ref("classes/users"),
-        ts: 11
-      }]
-    },
-    indexes: {
-      data: [{
-        name: "all_users",
-        ref: q.Ref("indexes/all_users"),
-        source: q.Ref("classes/users"),
-        ts: 12
-      }]
-    }
-  },
-  schemaTree: Immutable.fromJS({
-    info: {
-      name: "my-app",
-      ref: q.Ref("databases/my-app"),
-      ts: 123,
-      schemaLoaded: true,
-      databasesLoaded: true
-    },
-    databases: {},
-    classes: {
-      byName: {
-        "users": {
-          name: "users",
-          ref: q.Ref("classes/users"),
-          ts: 11
-        },
-      },
-      cursor: null
-    },
-    indexes: {
-      byName: {
-        "all_users": {
-          name: "all_users",
-          source: q.Ref("classes/users"),
-          ref: q.Ref("indexes/all_users"),
-          ts: 12
-        },
-      },
-      cursor: null
-    }
-  })
+  client.queryWithPrivilegesOrElse.mockImplementation((path, keyType, query) => Promise.resolve(
+    serverResponseByDatabasePathAndKeyType.getIn([path.join("/"), keyType]).toJS()
+  ))
+
+  return client
 }
 
 describe("Given a schema tree store", () => {
-  let store, schema, faunaClient
+  let store, schema, client
 
   beforeEach(() => {
-    store = createImmutableTestStore({
-      schema: reduceSchemaTree
-    })(state => schema = state.get("schema").toJS())
-
-    faunaClient = {
-      query: jest.fn(),
-      queryWithPrivilegesOrElse: jest.fn(),
-      hasPrivileges: jest.fn(() => true)
-    }
-  })
-
-  it("should load schema tree at root", () => {
-    faunaClient.queryWithPrivilegesOrElse.mockImplementation((path, keyType, query) => {
-      if (keyType === KeyType.ADMIN) return Promise.resolve(rootDatabase.adminKeyResponse)
-      if (keyType === KeyType.SERVER) return Promise.resolve(rootDatabase.serverKeyResponse)
-      return Promise.reject()
-    })
-
-    return store.dispatch(loadSchemaTree(faunaClient)).then(() => {
-      expect(schema).toEqual(rootDatabase.schemaTree.toJS())
-    })
-  })
-
-  it("should load deep nested databases", () => {
-    faunaClient.queryWithPrivilegesOrElse.mockReturnValue(
-      Promise.resolve(subDatabase.serverKeyResponse)
+    store = createImmutableTestStore({ schema: reduceSchemaTree })(
+      state => schema = state.get("schema").toJS()
     )
 
-    return store.dispatch(loadSchemaTree(faunaClient, ["my-app", "my-blog"])).then(() => {
-      expect(schema).toEqual(
-        Immutable.fromJS({
-          info: { name: "/" }
-        })
-        .setIn(
-          ["databases", "byName", "my-app", "info"],
-          Map.of("name", "my-app")
-        )
-        .setIn(
-          ["databases", "byName", "my-app", "databases", "byName", "my-blog"],
-          subDatabase.schemaTree.set("info", Map.of(
-            "name", "my-blog",
-            "databasesLoaded", true,
-            "schemaLoaded", true
-          ))
-        )
-        .toJS()
-      )
+    client = mockFaunaClient()
+  })
+
+  it("should load schema tree at root database", () => {
+    return store.dispatch(loadSchemaTree(client)).then(() => {
+      expect(schema).toEqual({
+        info: { name: "/", databasesLoaded: true, schemaLoaded: true },
+        databases: {
+          byName: {
+            production: {
+              info: { name: "production", ref: q.Ref("databases/production") },
+              databases: {},
+              classes: {},
+              indexes: {}
+            },
+          },
+          cursor: null
+        },
+        classes: {},
+        indexes: {}
+      })
     })
+  })
+
+  it("should load nested databases", () => {
+    return store.dispatch(loadSchemaTree(client, ["production", "site", "tenants"])).then(() => {
+      expect(schema).toEqual({
+        info: { name: "/" },
+        databases: {
+          byName: {
+            production: {
+              info: { name: "production" },
+              databases: {
+                byName: {
+                  site: {
+                    info: { name: "site" },
+                    databases: {
+                      byName: {
+                        tenants: {
+                          info: { name: "tenants", databasesLoaded: true, schemaLoaded: true },
+                          databases: {
+                            byName: {
+                              user123: {
+                                info: { name: "user123", ref: q.Ref("databases/user123") },
+                                databases: {}, classes: {}, indexes: {}
+                              }
+                            },
+                            cursor: null
+                          },
+                          classes: {}, indexes: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+    })
+  })
+
+  it("should load the rest of the database tree in background", (done) => {
+    store.dispatch(loadSchemaTree(client, ["production", "site", "tenants"], () => {
+      expect(schema).toEqual({
+        info: { name: "/", databasesLoaded: true },
+        databases: {
+          byName: {
+            production: {
+              info: { name: "production", databasesLoaded: true },
+              databases: {
+                byName: {
+                  site: {
+                    info: { name: "site", databasesLoaded: true },
+                    databases: {
+                      byName: {
+                        tenants: {
+                          info: { name: "tenants", databasesLoaded: true, schemaLoaded: true },
+                          databases: {
+                            byName: {
+                              user123: {
+                                info: { name: "user123", ref: q.Ref("databases/user123"), databasesLoaded: true },
+                                databases: {}, classes: {}, indexes: {}
+                              }
+                            },
+                            cursor: null
+                          },
+                          classes: {}, indexes: {}
+                        }
+                      },
+                      cursor: null
+                    },
+                    classes: {}, indexes: {}
+                  },
+                  blog: {
+                    info: { name: "blog", databasesLoaded: true },
+                    databases: {}, classes: {}, indexes: {}
+                  }
+                },
+                cursor: null
+              },
+              classes: {}, indexes: {}
+            }
+          },
+          cursor: null
+        },
+        classes: {}, indexes: {}
+      })
+      done()
+    }))
   })
 
   describe("when the root database is already loaded", () => {
-    beforeEach(() => {
-      store = store.withInitialState({
-        schema: rootDatabase.schemaTree
-      })
-    })
+    beforeEach((done) => store.dispatch(loadSchemaTree(client, [], () => {
+      client = mockFaunaClient()
+      done()
+    })))
 
     it("should not load the same database again", () => {
-      return store.dispatch(loadSchemaTree(faunaClient, [])).then(() => {
-        expect(faunaClient.queryWithPrivilegesOrElse).not.toHaveBeenCalled()
+      return store.dispatch(loadSchemaTree(client, [])).then(() => {
+        expect(client.queryWithPrivilegesOrElse).not.toHaveBeenCalled()
       })
     })
 
     it("should be able to load a sub-database", () => {
-      faunaClient.queryWithPrivilegesOrElse.mockReturnValue(
-        Promise.resolve(subDatabase.serverKeyResponse)
-      )
-
-      return store.dispatch(loadSchemaTree(faunaClient, ["my-app"])).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree
-          .setIn(["databases", "byName", "my-app"], subDatabase.schemaTree)
-          .toJS()
-        )
+      return store.dispatch(loadSchemaTree(client, ["production", "site"])).then(() => {
+        expect(schema.databases.byName.production.databases.byName.site).toEqual({
+          info: {
+            name: "site",
+            ref: q.Ref("databases/site"),
+            databasesLoaded: true,
+            schemaLoaded: true,
+          },
+          databases: {
+            byName: {
+              tenants: {
+                info: {
+                  name: "tenants",
+                  ref: q.Ref("databases/tenants")
+                },
+                databases: {},
+                classes: {},
+                indexes: {}
+              }
+            },
+            cursor: null
+          },
+          classes: {
+            byName: {
+              users: {
+                name: "users",
+                ref: q.Ref("classes/users")
+              }
+            },
+            cursor: null
+          },
+          indexes: {
+            byName: {
+              all_users: {
+                name: "all_users",
+                ref: q.Ref("indexes/all_users")
+              }
+            },
+            cursor: null
+          }
+        })
       })
     })
 
-    it("should be able to load a more databases", () => {
-      faunaClient.queryWithPrivilegesOrElse.mockReturnValue(
+
+    it("should be able to load more databases based on a cursor", () => {
+      client.queryWithPrivilegesOrElse.mockReturnValue(
         Promise.resolve({
           databases: {
             data: [{
-              name: "another-db"
+              name: "nested"
             }]
           }
         })
       )
 
-      return store.dispatch(loadDatabases(faunaClient, [], "database-cursor")).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree
-            .setIn(["databases", "byName", "another-db"], {
-              info: { name: "another-db" },
-              databases: {},
-              classes: {},
-              indexes: {}
-            })
-            .setIn(["databases", "cursor"], null)
-            .toJS()
-        )
+      return store.dispatch(loadDatabases(client, ["production"], "cursor")).then(() => {
+        expect(schema.databases.byName.production.databases.byName.nested).toEqual({
+          info: { name: "nested" },
+          databases: {},
+          classes: {},
+          indexes: {}
+        })
       })
     })
 
-    it("should not load databases if cursor is new and databases are already loaded", () => {
-      return store.dispatch(loadDatabases(faunaClient, [], null)).then(() => {
-        expect(faunaClient.queryWithPrivilegesOrElse).not.toHaveBeenCalled()
+    it("should not load databases if already loaded", () => {
+      return store.dispatch(loadDatabases(client, [], null)).then(() => {
+        expect(client.queryWithPrivilegesOrElse).not.toHaveBeenCalled()
       })
+    })
+
+    it("should load nested databases in background", (done) => {
+      client.queryWithPrivilegesOrElse.mockReturnValue(
+        Promise.resolve({
+          databases: {
+            data: [{
+              name: "nested"
+            }]
+          }
+        })
+      )
+
+      store.dispatch(loadDatabases(client, ["production"], "cursor", () => {
+        expect(schema.databases.byName.production.databases.byName.nested).toEqual({
+          info: { name: "nested", databasesLoaded: true },
+          databases: {
+            byName: {
+              nested: {
+                info: { name: "nested" },
+                databases: {}, classes: {}, indexes: {}
+              }
+            },
+            cursor: null,
+          },
+          classes: {}, indexes: {}
+        })
+        done()
+      }))
+    })
+
+    it("should load nested databases in background when no cursor", (done) => {
+      store.dispatch(loadDatabases(client, ["production"], null, () => {
+        expect(schema.databases.byName.production.databases.byName.site).toEqual({
+          info: { name: "site", ref: q.Ref("databases/site"), databasesLoaded: true },
+          databases: {
+            byName: {
+              tenants: {
+                info: { name: "tenants", ref: q.Ref("databases/tenants") },
+                databases: {}, classes: {}, indexes: {}
+              }
+            },
+            cursor: null,
+          },
+          classes: {}, indexes: {}
+        })
+        done()
+      }))
     })
 
     it("should be able to create a new database", () => {
-      faunaClient.query.mockReturnValue(Promise.resolve({
-        name: "new-db"
-      }))
-
-      return store.dispatch(createDatabase(faunaClient, [], { name: "new-db" })).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree.setIn(
-            ["databases", "byName", "new-db"],
-            Immutable.fromJS({
-              info: {
-                name: "new-db"
-              },
-              databases: {},
-              classes: {},
-              indexes: {}
-            })
-          ).toJS()
-        )
+      client.query.mockReturnValue(Promise.resolve({ name: "newdb" }))
+      return store.dispatch(createDatabase(client, [], { name: "newdb" })).then(() => {
+        expect(schema.databases.byName.newdb).toEqual({
+          info: { name: "newdb" },
+          databases: {},
+          classes: {},
+          indexes: {}
+        })
       })
     })
 
     it("should be able to delete a database", () => {
-      faunaClient.query.mockReturnValue(Promise.resolve())
-
-      return store.dispatch(deleteDatabase(faunaClient, [], "my-app")).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree
-            .removeIn(["databases", "byName", "my-app"])
-            .toJS()
-        )
+      client.query.mockReturnValue(Promise.resolve())
+      return store.dispatch(deleteDatabase(client, [], "production")).then(() => {
+        expect(schema.databases.byName).toEqual({})
       })
     })
 
     it("should be able to create a new class", () => {
-      faunaClient.query.mockReturnValue(Promise.resolve({
-        name: "new-class"
-      }))
-
-      return store.dispatch(createClass(faunaClient, ["my-app"], { name: "new-class" })).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree.setIn(
-            ["databases", "byName", "my-app", "classes", "byName", "new-class"],
-            Immutable.fromJS({
-              name: "new-class"
-            })
-          ).toJS()
-        )
+      client.query.mockReturnValue(Promise.resolve({ name: "newclass" }))
+      return store.dispatch(createClass(client, ["production"], { name: "newclass" })).then(() => {
+        expect(schema.databases.byName.production.classes.byName.newclass).toEqual({
+          name: "newclass"
+        })
       })
     })
 
     it("should be able to delete a class", () => {
-      faunaClient.query.mockReturnValue(Promise.resolve())
-
-      return store.dispatch(deleteClass(faunaClient, [], "people")).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree
-            .removeIn(["classes", "byName", "people"])
-            .toJS()
-        )
+      client.query.mockReturnValue(Promise.resolve())
+      return store.dispatch(deleteClass(client, ["production", "site"], "users")).then(() => {
+        expect(schema.databases.byName.production.databases.byName.site.classes).toEqual({})
       })
     })
 
     it("should be able to create a new index", () => {
-      faunaClient.query.mockReturnValue(Promise.resolve({
-        name: "new-index"
-      }))
-
-      return store.dispatch(createIndex(faunaClient, ["my-app"], { name: "new-index" })).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree.setIn(
-            ["databases", "byName", "my-app", "indexes", "byName", "new-index"],
-            Immutable.fromJS({
-              name: "new-index"
-            })
-          ).toJS()
-        )
+      client.query.mockReturnValue(Promise.resolve({ name: "newindex" }))
+      return store.dispatch(createIndex(client, ["production"], { name: "newindex" })).then(() => {
+        expect(schema.databases.byName.production.indexes.byName.newindex).toEqual({
+          name: "newindex"
+        })
       })
     })
 
     it("should be able to delete an index", () => {
-      faunaClient.query.mockReturnValue(Promise.resolve())
-
-      return store.dispatch(deleteIndex(faunaClient, [], "all_people")).then(() => {
-        expect(schema).toEqual(
-          rootDatabase.schemaTree
-            .removeIn(["indexes", "byName", "all_people"])
-            .toJS()
-        )
+      client.query.mockReturnValue(Promise.resolve())
+      return store.dispatch(deleteIndex(client, ["production", "site"], "all_users")).then(() => {
+        expect(schema.databases.byName.production.databases.byName.site.indexes).toEqual({})
       })
     })
   })

--- a/src/new-dash/schema/components/custom-nav.js
+++ b/src/new-dash/schema/components/custom-nav.js
@@ -11,7 +11,7 @@ export default class CustomNav extends Nav {
 
     return <div key={link.key || linkIndex}
         className={css("ms-Nav-compositeLink", {"is-expanded": link.isExpanded, "is-selected": isLinkSelected })}>
-          {(link.links && link.links.length > 0 ?
+          {((link.links && link.links.length > 0) || (this.props.alwaysShowExpandButton && !link.onClick) ?
             <button
               style={{paddingLeft: paddingBefore}}
               className="ms-Nav-chevronButton ms-Nav-chevronButton--link"
@@ -22,6 +22,11 @@ export default class CustomNav extends Nav {
           )}
         {!!link.onClick ? this._renderButtonLink(link, linkIndex) : this._renderAnchorLink(link, linkIndex, nestingLevel)}
       </div>
+  }
+
+  _onLinkExpandClicked(link, ev) {
+    this.props.onExpand && this.props.onExpand(link)
+    super._onLinkExpandClicked(link, ev)
   }
 }
 

--- a/src/new-dash/schema/components/custom-nav.js
+++ b/src/new-dash/schema/components/custom-nav.js
@@ -25,7 +25,16 @@ export default class CustomNav extends Nav {
   }
 
   _onLinkExpandClicked(link, ev) {
-    this.props.onExpand && this.props.onExpand(link)
+    if (this.props.onExpand) {
+      const res = this.props.onExpand(link) || Promise.resolve()
+      res.then(() => this.setState({ isLinkExpandStateChanged: true }))
+
+      link.isExpanded = !link.isExpanded
+      ev.preventDefault()
+      ev.stopPropagation()
+      return
+    }
+
     super._onLinkExpandClicked(link, ev)
   }
 }

--- a/src/new-dash/schema/components/custom-nav.js
+++ b/src/new-dash/schema/components/custom-nav.js
@@ -11,7 +11,7 @@ export default class CustomNav extends Nav {
 
     return <div key={link.key || linkIndex}
         className={css("ms-Nav-compositeLink", {"is-expanded": link.isExpanded, "is-selected": isLinkSelected })}>
-          {((link.links && link.links.length > 0) || (this.props.alwaysShowExpandButton && !link.onClick) ?
+          {((link.links && link.links.length > 0) ?
             <button
               style={{paddingLeft: paddingBefore}}
               className="ms-Nav-chevronButton ms-Nav-chevronButton--link"

--- a/src/new-dash/schema/components/custom-nav.js
+++ b/src/new-dash/schema/components/custom-nav.js
@@ -1,15 +1,19 @@
 import React from "react"
 import { Nav, css } from "office-ui-fabric-react"
 
+const _indentationSize = 14
+
 // Custom Nav to add chevron icon to all sub levels and control selected items
 export default class CustomNav extends Nav {
   _renderCompositeLink(link, linkIndex, nestingLevel) {
     const isLinkSelected = _isLinkSelected(link, this.props.selectedKey)
+    const paddingBefore = (_indentationSize * nestingLevel).toString(10) + 'px'
 
     return <div key={link.key || linkIndex}
         className={css("ms-Nav-compositeLink", {"is-expanded": link.isExpanded, "is-selected": isLinkSelected })}>
           {(link.links && link.links.length > 0 ?
             <button
+              style={{paddingLeft: paddingBefore}}
               className="ms-Nav-chevronButton ms-Nav-chevronButton--link"
               onClick={this._onLinkExpandClicked.bind(this, link)}
               title={(link.isExpanded ? this.props.expandedStateText : this.props.collapsedStateText)}>

--- a/src/new-dash/schema/components/nav-db-tree.js
+++ b/src/new-dash/schema/components/nav-db-tree.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux"
 import { browserHistory } from "react-router"
 
 import CustomNav from "./custom-nav"
-import { databaseTree, loadSchemaTree, loadMoreDatabases } from "../"
+import { databaseTree, loadDatabases } from "../"
 import { selectedResource, buildResourceUrl } from "../../router"
 import { faunaClient } from "../../authentication"
 import { watchForError } from "../../notifications"
@@ -42,7 +42,7 @@ class NavDBTree extends Component {
         name: db.get("name"),
         path: db.get("path"),
         links: this.databaseLinks(db, link.links || []),
-        isExpanded: link.isExpanded === undefined ? false : link.isExpanded
+        isExpanded: link.isExpanded === undefined ? !db.get("databases").isEmpty() : link.isExpanded
       }
     }
 
@@ -82,7 +82,7 @@ class NavDBTree extends Component {
       monitorActivity(
         watchForError(
           "Unexpected error while fetching databases",
-          loadMoreDatabases(this.props.client, dbPath, cursor)
+          loadDatabases(this.props.client, dbPath, cursor)
         )
       )
     )
@@ -94,11 +94,13 @@ class NavDBTree extends Component {
   }
 
   onExpand(link) {
-    this.props.dispatch(
+    if (link.isExpanded) return
+
+    return this.props.dispatch(
       monitorActivity(
         watchForError(
           "Unexpected error while fetching schema information",
-          loadSchemaTree(this.props.client, link.path)
+          loadDatabases(this.props.client, link.path)
         )
       )
     )

--- a/src/new-dash/schema/components/nav-db-tree.js
+++ b/src/new-dash/schema/components/nav-db-tree.js
@@ -42,7 +42,8 @@ class NavDBTree extends Component {
         name: db.get("name"),
         path: db.get("path"),
         links: this.databaseLinks(db, link.links || []),
-        isExpanded: link.isExpanded === undefined ? !db.get("databases").isEmpty() : link.isExpanded
+        isExpanded: link.isExpanded !== undefined ? link.isExpanded :
+          !db.get("databases").isEmpty() && key !== this.props.databaseUrl
       }
     }
 

--- a/src/new-dash/schema/path.js
+++ b/src/new-dash/schema/path.js
@@ -11,3 +11,9 @@ export const nestedDatabaseNodeIn = (path, node) => {
 
   return nodePath
 }
+
+export const allDatabasesPaths = path => List(path).reduce(
+  (paths, name) => paths.push(paths.last().push(name)),
+  List.of(List())
+)
+


### PR DESCRIPTION
Closes: #154, #155

This is an alternative solution to what was proposed at #155.

The original approach was to load the sub-databases information when the user selects a database so we would be able to identify the databases that has nested databases and show the expand icon for them.

This implementation is complex for some reasons:
- It increases the number of calls to the server as a function of the number of nested databases for each level of the schema tree
- If you select a nested database and refresh the page, the only way to keep the schema tree consistent is to not only load the sub-databases but also parent databases up to the root db. Otherwise you have a false notion that you're database tree is loaded but, as you select other levels, more databases show up.

This PR proposes a different approach:
- We always load the root database as the user logs in (or its session gets restored)
- We always show the expand button along with the databases. That gives the user the correct notion that databases might have nested databases in it.
- If the database has no sub databases, we show a "Add a new database" button as the user expands the tree.
- When the user clicks on the expand button, we load the schema information for the selected database.

![image](https://cloud.githubusercontent.com/assets/813042/23308269/66a14320-fa89-11e6-8cd6-8d372925a56a.png)
