### PR TITLE
Display fauna error messages when notifying about a failure

### DIFF
--- a/src/new-dash/notifications/components/notification-bar.js
+++ b/src/new-dash/notifications/components/notification-bar.js
@@ -20,7 +20,9 @@ const NotificationBar = ({ notifications }) => {
         <li key={index} className="ms-u-fadeIn100">
           <MessageBar
             messageBarType={messageBarTypeFor(notification.type)}>
-            {notification.message}
+            {notification.message.split("\n").map((text, key) =>
+              <span key={key}>{text}<br/></span>
+            )}
           </MessageBar>
         </li>
       ))

--- a/src/new-dash/notifications/notification-center.js
+++ b/src/new-dash/notifications/notification-center.js
@@ -29,6 +29,25 @@ const push = (dispatch, type, message) => {
   )
 }
 
+const buildErrorMessage = (message, error) => {
+  let result = `${message ? message + ". " : ""}${error}`
+
+  if (error.errors) {
+    error.errors().forEach(err => {
+      result += `\n\n> ${err.description}`
+
+      if (err.failures) {
+        err.failures.forEach(failure => {
+          result += `\n  - (${failure.field.join(".")}): ${failure.description}`
+        })
+      }
+    })
+  }
+
+  return result
+}
+
+
 export const watchForError = (message, action) => (dispatch) => {
   let res
 
@@ -39,7 +58,7 @@ export const watchForError = (message, action) => (dispatch) => {
   }
 
   return res.catch(error => {
-    push(dispatch, NotificationType.ERROR, `${message ? message + ". " : ""}${error}`)
+    push(dispatch, NotificationType.ERROR, buildErrorMessage(message, error))
     throw error
   })
 }


### PR DESCRIPTION
Scenario:
1. Using fauna cloud
1. Create a class
1. Delete the class
1. Try to create a class with the same name before 60 seconds

Before: 
![image](https://cloud.githubusercontent.com/assets/813042/23554427/c7be0a74-0003-11e7-9055-48d7cf580116.png)

Now:
![image](https://cloud.githubusercontent.com/assets/813042/23554443/df1de5a4-0003-11e7-9823-e10036fbd315.png)
