### PR TITLE
Use two flags to enable or disable new dashboard

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ import './index.css';
 
 import Cookies from "js-cookie"
 
-if (Cookies.get("USE_NEW_SCHEMA_TREE")) {
+const useNewDash = Cookies.get("USE_NEW_DASH")
+const useOldDash = Cookies.get("USE_OLD_DASH")
+
+if (useNewDash === "true" && (!useOldDash || useOldDash === "false")) {
   require("./new-dash/index.js")
 } else {
   var middlewares = [thunk]


### PR DESCRIPTION
With this two flags, we can test old and new dash in prod even after we force nginx to set the feature flag on by default.