### PR TITLE
Fix browser compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ import { reduceNotifications } from "./notifications"
 import { reduceActivityMonitor } from "./activity-monitor"
 import { reduceUserSession } from "./authentication"
 
+require("./lang/polyfill.js")
+
 const store = (() => {
   const middlewares = [thunk]
 

--- a/src/lang/polyfill.js
+++ b/src/lang/polyfill.js
@@ -1,0 +1,6 @@
+if (!Object.values) {
+  Object.values = (obj) =>
+    Object
+      .keys(obj)
+      .map(key => obj[key])
+}

--- a/src/repl/components/editor.css
+++ b/src/repl/components/editor.css
@@ -1,5 +1,6 @@
 .editor {
     width: 100%;
+    position: absolute;
 }
 
 .editor.code-editor {


### PR DESCRIPTION
I've found two browsers incompatibilities:
- `Object.values` is not available in Safari
- Toggle repl was not showing up in Safari