### PR TITLE
Make component tests more isolated

### DIFF
--- a/src/activity-monitor/components/__tests__/__snapshots__/activity-monitor.js.snap
+++ b/src/activity-monitor/components/__tests__/__snapshots__/activity-monitor.js.snap
@@ -1,11 +1,7 @@
-exports[`ActivityMonitor Component should turn spinner on and off when monitoring activity 1`] = `null`;
+exports[`test should turn spinner OFF when NOT monitoring activity 1`] = `null`;
 
-exports[`ActivityMonitor Component should turn spinner on and off when monitoring activity 2`] = `
-<div
-  className="ms-Spinner activity-monitor">
-  <div
-    className="ms-Spinner-circle ms-Spinner--normal" />
-</div>
+exports[`test should turn spinner ON when monitoring activity 1`] = `
+<Spinner
+  className="activity-monitor"
+  type={0} />
 `;
-
-exports[`ActivityMonitor Component should turn spinner on and off when monitoring activity 3`] = `null`;

--- a/src/activity-monitor/components/__tests__/activity-monitor.js
+++ b/src/activity-monitor/components/__tests__/activity-monitor.js
@@ -1,25 +1,15 @@
 import React from "react"
-import renderer from "react-test-renderer"
+import { shallow } from "enzyme"
+import { shallowToJson } from "enzyme-to-json"
 
-import { reduceActivityMonitor, monitorActivity, ActivityMonitor } from "../../"
+import { ActivityMonitor } from "../activity-monitor"
 
-describe("ActivityMonitor Component", () => {
-  let comp, store
+it("should turn spinner ON when monitoring activity", () => {
+  const comp = shallow(<ActivityMonitor isBusy={true} /> )
+  expect(shallowToJson(comp)).toMatchSnapshot()
+})
 
-  beforeEach(() => {
-    store = createImmutableTestStore({ activityMonitor: reduceActivityMonitor })()
-    comp = renderer.create(<ActivityMonitor store={store} />)
-    expect(comp).toMatchSnapshot()
-  })
-
-  it("should turn spinner on and off when monitoring activity", () => {
-    return store.dispatch(
-      monitorActivity(() => {
-        expect(comp).toMatchSnapshot() // Inside monitor. Display spinner
-        return Promise.resolve()
-      })
-    ).then(() => {
-      expect(comp).toMatchSnapshot() // Outside monitor. Hide spinner
-    })
-  })
+it("should turn spinner OFF when NOT monitoring activity", () => {
+  const comp = shallow(<ActivityMonitor isBusy={false} /> )
+  expect(shallowToJson(comp)).toMatchSnapshot()
 })

--- a/src/activity-monitor/components/activity-monitor.js
+++ b/src/activity-monitor/components/activity-monitor.js
@@ -5,7 +5,7 @@ import { Spinner } from "office-ui-fabric-react"
 import "./activity-monitor.css"
 import { isBusy } from "../"
 
-const ActivityMonitor = (props) => {
+export const ActivityMonitor = (props) => {
   if (!props.isBusy) return null
   return <Spinner className="activity-monitor" />
 }

--- a/src/authentication/components/__tests__/user-account.js
+++ b/src/authentication/components/__tests__/user-account.js
@@ -2,27 +2,14 @@ import React from "react"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import { reduceUserSession, UserAccount } from "../../"
-
-// We can't use enzyme#mount to render components that are
-// dependent on Fabric's Callout component because it changes
-// the DOM adding elemenents at the body, outside of the this
-// component's scope.
-//
-// The elements added by Fabric have cicular dependencies to the
-// elements on this component, breaking attempts to take JSON
-// snapshots from them.
+import { UserAccount } from "../user-account"
 
 describe("UserAccount Component", () => {
-  let comp, store, currentUser
+  let comp, dispatch
 
   beforeEach(() => {
-    currentUser = { name: "mocked user" }
-    store = createImmutableTestStore({ currentUser: reduceUserSession }, { currentUser })(
-      state => currentUser = state.get("currentUser")
-    )
-
-    comp = shallow(<UserAccount store={store} />).dive()
+    dispatch = jest.fn()
+    comp = shallow(<UserAccount dispatch={dispatch} />)
   })
 
   it("should show and hide context menu on click", () => {
@@ -31,15 +18,19 @@ describe("UserAccount Component", () => {
     comp.find("Button").simulate("click", { target: "mocked" })
     expect(shallowToJson(comp)).toMatchSnapshot()
 
-    // Can't simulate using the DOM. Read above.
-    comp.instance().hideMenu()
-    comp.update()
+    comp.find("ContextualMenu").simulate("dismiss")
     expect(shallowToJson(comp)).toMatchSnapshot()
   })
 
-  it("should show context menu on click", () => {
-    // Can't simulate using the DOM. Read above.
-    comp.instance().logout()
-    expect(currentUser).toBeNull()
+  it("should logout", () => {
+    comp.setState({ menuVisible: true })
+
+    comp
+      .find("ContextualMenu")
+      .prop("items")
+      .filter(i => i.key === "logout-btn")[0]
+      .onClick()
+
+    expect(dispatch).toHaveBeenCalled()
   })
 })

--- a/src/authentication/components/user-account.js
+++ b/src/authentication/components/user-account.js
@@ -9,7 +9,8 @@ import {
 
 import { logout } from "../"
 
-class UserAccount extends Component {
+export class UserAccount extends Component {
+
   constructor(props) {
     super(props)
     this.state = { showMenu: false }

--- a/src/schema/components/__tests__/__snapshots__/keys-manager.js.snap
+++ b/src/schema/components/__tests__/__snapshots__/keys-manager.js.snap
@@ -1,4 +1,4 @@
-exports[`KeysManager Component should keys containment message when not a root database 1`] = `
+exports[`test should keys containment message when not a root database 1`] = `
 <div>
   <Pivot>
     <PivotItem
@@ -29,7 +29,7 @@ exports[`KeysManager Component should keys containment message when not a root d
 </div>
 `;
 
-exports[`KeysManager Component should render for root db 1`] = `
+exports[`test should render for root db 1`] = `
 <div>
   <Pivot>
     <PivotItem

--- a/src/schema/components/__tests__/class-delete.js
+++ b/src/schema/components/__tests__/class-delete.js
@@ -3,13 +3,14 @@ import { Map } from "immutable"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import ClassDelete from "../class-delete"
-import { reduceSchemaTree } from "../../"
+import { ClassDelete } from "../class-delete"
+
+jest.mock("../../../notifications", () => ({
+  notify: (msg, fn) => fn(() => Promise.resolve())
+}))
 
 jest.mock("react-router", () => ({
-  browserHistory: {
-    push: jest.fn()
-  }
+  browserHistory: { push: jest.fn() }
 }))
 
 const { browserHistory } = require("react-router")
@@ -18,17 +19,13 @@ describe("ClassDelete Component", () => {
   let comp, store, client
 
   beforeEach(() => {
-    client = { query: jest.fn(() => Promise.resolve()) }
-    store = createImmutableTestStore({ schema: reduceSchemaTree })()
-
     comp = shallow(
       <ClassDelete
-        store={store}
         client={client}
         path={["a-db"]}
         clazz={Map.of("name", "fake-class")}
         dbUrl="/db/a-db/databases" />
-    ).dive()
+    )
   })
 
   it("renders delete form", () => {
@@ -36,7 +33,7 @@ describe("ClassDelete Component", () => {
   })
 
   it("delete class", () => {
-    return store.dispatch(comp.props().onDelete()).then(() => {
+    return comp.props().onDelete().then(() => {
       expect(browserHistory.push).toHaveBeenCalledWith("/db/a-db/classes")
     })
   })

--- a/src/schema/components/__tests__/class-info.js
+++ b/src/schema/components/__tests__/class-info.js
@@ -3,11 +3,10 @@ import { Map, List } from "immutable"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import ClassInfo from "../class-info"
-import { reduceSchemaTree } from "../../"
+import { ClassInfo } from "../class-info"
 
 describe("ClassInfo Component", () => {
-  let clazz, store
+  let clazz
 
   beforeEach(() => {
     clazz = Map.of(
@@ -21,21 +20,19 @@ describe("ClassInfo Component", () => {
         )
       )
     )
-
-    store = createImmutableTestStore({ schema: reduceSchemaTree })()
   })
 
   it("renders class details", () => {
-    const comp = shallow(<ClassInfo store={store} clazz={clazz} />).dive()
+    const comp = shallow(<ClassInfo clazz={clazz} />)
     expect(shallowToJson(comp)).toMatchSnapshot()
   })
 
   it("renders class when no history or ttl", () => {
-    const c = clazz.set("historyDays", null).set("ttlDays", null)
-    const comp = shallow(<ClassInfo store={store} clazz={c} />).dive()
+    const clazzWithNoHistory = clazz
+      .set("historyDays", null)
+      .set("ttlDays", null)
+
+    const comp = shallow(<ClassInfo clazz={clazzWithNoHistory} />)
     expect(shallowToJson(comp)).toMatchSnapshot()
   })
 })
-
-
-

--- a/src/schema/components/__tests__/class-instance.js
+++ b/src/schema/components/__tests__/class-instance.js
@@ -3,23 +3,19 @@ import { Map } from "immutable"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import ClassInstance from "../class-instance"
-import { reduceSchemaTree } from "../../"
+import { ClassInstance } from "../class-instance"
+
+jest.mock("../../../notifications", () => ({
+  notify: (msg, fn) => fn()
+}))
 
 describe("ClassInstance Component", () => {
-  let comp, store, client
+  let comp, client
 
   beforeEach(() => {
+    const clazz = Map.of("name", "fake-class")
     client = { query: jest.fn(() => Promise.resolve({ name: "fake-instance" })) }
-    store = createImmutableTestStore({ schema: reduceSchemaTree })()
-
-    comp = shallow(
-      <ClassInstance
-        store={store}
-        client={client}
-        path={["a-db"]}
-        clazz={Map.of("name", "fake-class")} />
-    ).dive()
+    comp = shallow(<ClassInstance client={client} path={["a-db"]} clazz={clazz} />)
   })
 
   it("renders instance form", () => {
@@ -30,11 +26,9 @@ describe("ClassInstance Component", () => {
     comp.find("ReplEditor").simulate("change", "{ 'name': 'Bob' }")
     expect(shallowToJson(comp)).toMatchSnapshot()
 
-    return store.dispatch(comp.find("Connect(SchemaForm)").props().onSubmit()).then(() => {
+    return comp.find("Connect(SchemaForm)").props().onSubmit().then(() => {
       comp.update()
       expect(shallowToJson(comp)).toMatchSnapshot()
     })
   })
 })
-
-

--- a/src/schema/components/__tests__/keys-form.js
+++ b/src/schema/components/__tests__/keys-form.js
@@ -3,8 +3,11 @@ import Immutable from "immutable"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import KeysForm from "../keys-form"
-import { reduceSchemaTree } from "../../"
+import { KeysForm } from "../keys-form"
+
+jest.mock("../../../notifications", () => ({
+  notify: (msg, fn) => fn()
+}))
 
 const fill = (comp) => {
   comp.find("TextField[label='Name']").simulate("beforeChange", "server-key")
@@ -13,11 +16,9 @@ const fill = (comp) => {
 }
 
 describe("KeysForm Component", () => {
-  let comp, client, store
+  let comp, client
 
   beforeEach(() => {
-    store = createImmutableTestStore({ schema: reduceSchemaTree })()
-
     client = {
       query: jest.fn(() => Promise.resolve({
         secret: "one-time-secret"
@@ -26,7 +27,6 @@ describe("KeysForm Component", () => {
 
     comp = shallow(
       <KeysForm
-        store={store}
         client={client}
         database={Immutable.fromJS({
           databases: [
@@ -34,7 +34,7 @@ describe("KeysForm Component", () => {
             { name: "db2" }
           ]
         })} />
-    ).dive()
+    )
   })
 
   it("should render an empty form", () => {
@@ -50,7 +50,7 @@ describe("KeysForm Component", () => {
 
   it("should create a new key on submit", () => {
     fill(comp)
-    return store.dispatch(comp.instance().onSubmit()).then(() => {
+    return comp.find("Connect(SchemaForm)").props().onSubmit().then(() => {
       comp.find("Connect(SchemaForm)").simulate("finish")
       expect(shallowToJson(comp)).toMatchSnapshot() // Form clean + secret being displayed
     })

--- a/src/schema/components/__tests__/keys-manager.js
+++ b/src/schema/components/__tests__/keys-manager.js
@@ -3,30 +3,28 @@ import { Map } from "immutable"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import { reduceSchemaTree, KeysManager } from "../../"
+import { KeysManager } from "../keys-manager"
 
-describe("KeysManager Component", () => {
-  let store
+it("should render for root db", () => {
+  const db = Map.of(
+    "isRoot", true,
+    "name", "/",
+    "parent", null
+  )
 
-  beforeEach(() => {
-    store = createImmutableTestStore({ schema: reduceSchemaTree })()
-  })
+  const comp = shallow(<KeysManager database={db} />)
+  expect(shallowToJson(comp)).toMatchSnapshot()
+})
 
-  it("should render for root db", () => {
-    const comp = shallow(<KeysManager store={store} />).dive()
-    expect(shallowToJson(comp)).toMatchSnapshot()
-  })
-
-  it("should keys containment message when not a root database", () => {
-    const db = Map.of(
-      "isRoot", false,
-      "name", "subdb",
-      "parent", Map.of(
-        "url", "/db/parent/databases"
-      )
+it("should keys containment message when not a root database", () => {
+  const db = Map.of(
+    "isRoot", false,
+    "name", "subdb",
+    "parent", Map.of(
+      "url", "/db/parent/databases"
     )
+  )
 
-    const comp = shallow(<KeysManager store={store} database={db} />).dive()
-    expect(shallowToJson(comp)).toMatchSnapshot()
-  })
+  const comp = shallow(<KeysManager database={db} />)
+  expect(shallowToJson(comp)).toMatchSnapshot()
 })

--- a/src/schema/components/__tests__/nav-schema.js
+++ b/src/schema/components/__tests__/nav-schema.js
@@ -3,8 +3,7 @@ import { Map, List } from "immutable"
 import { shallow } from "enzyme"
 import { shallowToJson } from "enzyme-to-json"
 
-import NavSchema from "../nav-schema"
-import { reduceSchemaTree } from "../../"
+import { NavSchema } from "../nav-schema"
 
 jest.mock("react-router", () => ({
   browserHistory: {
@@ -15,14 +14,8 @@ jest.mock("react-router", () => ({
 const { browserHistory } = require("react-router")
 
 describe("NavSchema Component", () => {
-  let rootDb, subDb, store, client
-
-  const render = (db) => shallow(
-    <NavSchema
-      store={store}
-      client={client}
-      database={db} />
-  ).dive()
+  let rootDb, subDb, client
+  const render = (db) => shallow(<NavSchema client={client} database={db} />)
 
   beforeEach(() => {
     rootDb = Map.of(
@@ -40,7 +33,6 @@ describe("NavSchema Component", () => {
     )
 
     client = { hasPrivileges: jest.fn(() => true) }
-    store = createImmutableTestStore({ schema: reduceSchemaTree })()
   })
 
   it("should render classes and indexes for root db", () => {

--- a/src/schema/components/class-delete.js
+++ b/src/schema/components/class-delete.js
@@ -8,14 +8,12 @@ import { notify } from "../../notifications"
 import { faunaClient } from "../../authentication"
 import { buildResourceUrl } from "../../router"
 
-const ClassDelete = ({ client, path, dbUrl, clazz }) => {
-  const onDelete = () => {
-    return notify("Class deleted successfully", dispatch =>
-      dispatch(deleteClass(client, path, clazz.get("name"))).then(() =>
-        browserHistory.push(buildResourceUrl(dbUrl, "classes"))
-      )
+export const ClassDelete = ({ client, path, dbUrl, clazz }) => {
+  const onDelete = () => notify("Class deleted successfully", dispatch =>
+    dispatch(deleteClass(client, path, clazz.get("name"))).then(() =>
+      browserHistory.push(buildResourceUrl(dbUrl, "classes"))
     )
-  }
+  )
 
   return <DeleteForm
     buttonText="Delete Class"
@@ -28,11 +26,10 @@ const ClassDelete = ({ client, path, dbUrl, clazz }) => {
 ClassDelete.displayName = "ClassDelete"
 
 export default connect(
-  (state, props) => ({
+  state => ({
     client: faunaClient(state),
     path: selectedDatabase(state).get("path"),
     dbUrl: selectedDatabase(state).get("url"),
-    clazz: selectedClass(state),
-    ...props
+    clazz: selectedClass(state)
   })
 )(ClassDelete)

--- a/src/schema/components/class-info.js
+++ b/src/schema/components/class-info.js
@@ -4,7 +4,7 @@ import { Link } from "react-router"
 
 import { selectedClass } from "../"
 
-const ClassInfo = ({ clazz }) => {
+export const ClassInfo = ({ clazz }) => {
   const days = (value) => value !== null ? `${value} days` : ""
 
   return <div>
@@ -27,8 +27,7 @@ const ClassInfo = ({ clazz }) => {
 ClassInfo.displayName = "ClassInfo"
 
 export default connect(
-  (state, props) => ({
-    clazz: selectedClass(state),
-    ...props
+  state => ({
+    clazz: selectedClass(state)
   })
 )(ClassInfo)

--- a/src/schema/components/class-instance.js
+++ b/src/schema/components/class-instance.js
@@ -10,7 +10,7 @@ import { KeyType } from "../../persistence/faunadb-wrapper"
 import { ReplEditor, evalQuery } from "../../repl"
 import { InstanceInfo } from "../../dataset"
 
-class ClassInstance extends Component {
+export class ClassInstance extends Component {
 
   constructor(props) {
     super(props)
@@ -78,10 +78,9 @@ class ClassInstance extends Component {
 }
 
 export default connect(
-  (state, props) => ({
+  state => ({
     path: selectedDatabase(state).get("path"),
     clazz: selectedClass(state),
-    client: faunaClient(state),
-    ...props
+    client: faunaClient(state)
   })
 )(ClassInstance)

--- a/src/schema/components/keys-form.js
+++ b/src/schema/components/keys-form.js
@@ -9,7 +9,7 @@ import { notify } from "../../notifications"
 import { faunaClient } from "../../authentication"
 import { KeyType } from "../../persistence/faunadb-wrapper"
 
-class KeysForm extends Component {
+export class KeysForm extends Component {
 
   constructor(props) {
     super(props)
@@ -129,9 +129,8 @@ class KeysForm extends Component {
 }
 
 export default connect(
-  (state, props) => ({
+  state => ({
     client: faunaClient(state),
-    database: selectedDatabase(state),
-    ...props
+    database: selectedDatabase(state)
   })
 )(KeysForm)

--- a/src/schema/components/keys-list.js
+++ b/src/schema/components/keys-list.js
@@ -11,7 +11,7 @@ import { buildResourceUrl } from "../../router"
 import { Pagination, InstanceInfo } from "../../dataset"
 import { KeyType } from "../../persistence/faunadb-wrapper"
 
-class KeysList extends Component {
+export class KeysList extends Component {
 
   constructor(props) {
     super(props)
@@ -78,10 +78,9 @@ class KeysList extends Component {
 }
 
 export default connect(
-  (state, props) => ({
+  state => ({
     client: faunaClient(state),
     path: selectedDatabase(state).get("path"),
-    url: selectedDatabase(state).get("url"),
-    ...props
+    url: selectedDatabase(state).get("url")
   })
 )(KeysList)

--- a/src/schema/components/keys-manager.js
+++ b/src/schema/components/keys-manager.js
@@ -8,7 +8,7 @@ import KeysList from "./keys-list"
 import { selectedDatabase } from "../"
 import { buildResourceUrl } from "../../router"
 
-const KeysManager = ({ database }) => {
+export const KeysManager = ({ database }) => {
   return <div>
       <Pivot>
         <PivotItem linkText="Keys" itemKey="keys">
@@ -29,8 +29,7 @@ const KeysManager = ({ database }) => {
 }
 
 export default connect(
-  (state, props) => ({
-    database: selectedDatabase(state),
-    ...props
+  state => ({
+    database: selectedDatabase(state)
   })
 )(KeysManager)

--- a/src/schema/components/nav-schema.js
+++ b/src/schema/components/nav-schema.js
@@ -28,7 +28,7 @@ const asLinks = (items) => items.map(item => ({
   url: item.get("url")
 })).toJS()
 
-const NavSchema = ({ client, database, resourceUrl }) => {
+export const NavSchema = ({ client, database, resourceUrl }) => {
   const links = [
     {
       name: "Options",
@@ -55,10 +55,9 @@ const NavSchema = ({ client, database, resourceUrl }) => {
 }
 
 export default connect(
-  (state, props) => ({
+  state => ({
     client: faunaClient(state),
     database: selectedDatabase(state),
-    resourceUrl: selectedResource(state).getIn(["resource", "url"]),
-    ...props
+    resourceUrl: selectedResource(state).getIn(["resource", "url"])
   })
 )(NavSchema)


### PR DESCRIPTION
I was thinking about the way I've approached component testing recently and I wanted to refactor them a little bit before continue.

They were dependent on redux state, which makes them harder to test as we need to simulate transitions that are already tested by unit tests.

This is an attempt to make component tests isolated from redux state.