### PR TITLE
Remove duplicated NotificationBar when using a server key

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -100,7 +100,6 @@ export class Container extends Component {
         <NavTree />
       </div>
       <div className="ms-Grid-col ms-u-sm12 ms-u-md9 ms-u-lg10">
-        <NotificationBar />
         {this.props.children}
       </div>
     </div>


### PR DESCRIPTION
I think a merge conflict lead to this. There were 2 notification bars when logging in with a server key.