### PR TITLE
Disable ace finder since we don't support it

### DIFF
--- a/src/repl/components/editor.js
+++ b/src/repl/components/editor.js
@@ -63,9 +63,8 @@ export default class ReplEditor extends Component {
       faunaLangCompleter
     ]
 
-    shortcuts.forEach(shortcut => {
-      this.editor.commands.addCommand(shortcut)
-    })
+    this.editor.commands.removeCommand("find")
+    shortcuts.forEach(shortcut => this.editor.commands.addCommand(shortcut))
 
     this.editor.focus()
   }


### PR DESCRIPTION
Fixes: #225, #226 

Since we don't have the necessary modules to support ace find command, it causes an exception.
By disabling it, the default browser text finder will be used.