### PR TITLE
use the same analytics code as fauna.com

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -120,7 +120,7 @@ export default class App extends Component {
   // FIXME: GA should be extract as a plugin for could users only
   componentDidMount() {
     if (App.isProduction) {
-      ReactGA.initialize("UA-51914115-3")
+      ReactGA.initialize("UA-51914115-2")
     }
   }
 


### PR DESCRIPTION
If we switch the dashboard's Google Analytics code to use the same one as the fauna.com website, we'll get user and session continuity across the properties. I checked and the rest of the config is already set up properly for that, according to http://www.lunametrics.com/blog/2016/08/11/subdomain-tracking-google-analytics/ 

I think we want to do that. Can anyone think of a reason not to?