### PR TITLE
DT-2: Move cloud authentication to cloud dashboard only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -262,9 +262,9 @@
       "dev": true
     },
     "asap": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1008,9 +1008,9 @@
       "dev": true
     },
     "bytes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
-      "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
+      "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
       "dev": true
     },
     "caller-path": {
@@ -1066,15 +1066,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000698",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000698.tgz",
-      "integrity": "sha1-Yjot40WM7KN5hGqPFw57F3HHw6M=",
+      "version": "1.0.30000699",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000699.tgz",
+      "integrity": "sha1-WvSRqxx3dWGjK0P+JT1qcHHM+Xk=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000698",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000698.tgz",
-      "integrity": "sha1-gQLol4sfNpYvKhAkMuS/Tqx7bL4=",
+      "version": "1.0.30000699",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000699.tgz",
+      "integrity": "sha1-Khh7c37aqevtu7Vu3LU+mU7O2gw=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1304,24 +1304,10 @@
       "dev": true
     },
     "compression": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
-      "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
+      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2070,9 +2056,9 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "version": "0.10.24",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
+      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
       "dev": true
     },
     "es6-iterator": {
@@ -6967,9 +6953,9 @@
       "dev": true,
       "dependencies": {
         "ajv": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.1.tgz",
-          "integrity": "sha1-3NAwRRdYg7obY25a6ew9+auFMjo=",
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,21 @@
   "version": "0.1.0",
   "lockfileVersion": 1,
   "dependencies": {
+    "@microsoft/load-themed-styles": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.4.0.tgz",
+      "integrity": "sha1-GDC9288QFxLKJgIX5Vq3RKUgQdw="
+    },
+    "@uifabric/styling": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.13.5.tgz",
+      "integrity": "sha512-/rtcST8IEaSqJ900AsG+LVUGD8sTjgzfYjOo4DcAYufmw3XQyTs8jdo09MbsGbPWH/g/ru/UEl00p7zEHYElJQ=="
+    },
+    "@uifabric/utilities": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-4.7.1.tgz",
+      "integrity": "sha512-ll0PVLwECrwP6UxCG5+SR6Tu6C+leYsofacR5Y4ufDME/lRxI/eEIIKIXxSNt0s3AHA4FB43SXrOH7jkrZ14uQ=="
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -788,13 +803,11 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true,
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-          "dev": true
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
         }
       }
     },
@@ -1570,9 +1583,9 @@
       "dev": true
     },
     "crypto-browserify": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
-      "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "dev": true
     },
     "css-color-names": {
@@ -3301,6 +3314,11 @@
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
+    "glamor": {
+      "version": "2.20.25",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.25.tgz",
+      "integrity": "sha1-cbhLgrZ6kyd3GsWd5T7pFdFIpKM="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -3482,11 +3500,6 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
-    "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -3622,11 +3635,6 @@
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
       "dev": true
     },
-    "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3684,7 +3692,8 @@
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -4611,12 +4620,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -5153,6 +5158,11 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
       "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
       "dev": true
+    },
+    "office-ui-fabric-react": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-4.17.1.tgz",
+      "integrity": "sha512-qvJ0EqAFI9TeMhONRPHAdFEzHMGm0Zl343ZRQMrh29BdRFLTS863nQPWx3I36F5KFC1JD+GJzZvpWL0EGjJLwg=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -6529,11 +6539,6 @@
         }
       }
     },
-    "react-redux": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo="
-    },
     "react-test-renderer": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.1.tgz",
@@ -6650,26 +6655,11 @@
         }
       }
     },
-    "redux": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.1.tgz",
-      "integrity": "sha512-iEVTlORM5mv6xb3ZAOyrVehVUD+W87jdFAX6SYVgZh3/SQAWFSxTRJOqPWQdvo4VN4lJkNDvqKlBXBabsJTSkA=="
-    },
-    "redux-immutable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-3.1.0.tgz",
-      "integrity": "sha1-yvvWhuBxEmERm5wolgk13EeknQo="
-    },
     "redux-logger": {
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-2.10.2.tgz",
       "integrity": "sha1-PFpfCm8yV3wd6t9mVfJX+CxsOTc=",
       "dev": true
-    },
-    "redux-thunk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
     },
     "regenerate": {
       "version": "1.3.2",
@@ -6680,8 +6670,7 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.9.11",
@@ -6849,11 +6838,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "reselect": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz",
-      "integrity": "sha1-t9I/3wC4P6etAnlUb427vXZccEc="
-    },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
@@ -6889,6 +6873,11 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true
+    },
+    "rtl-css-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.1.1.tgz",
+      "integrity": "sha1-IZ0QchuARIRXcaA76i5cQ4eCECQ="
     },
     "run-async": {
       "version": "0.1.0",
@@ -7365,11 +7354,6 @@
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "dev": true
     },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -7553,6 +7537,11 @@
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
+      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
   "dependencies": {
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-redux": "^5.0.1",
-    "immutable": "^3.8.1",
-    "redux": "^3.6.0",
-    "redux-thunk": "^2.1.0",
-    "redux-immutable": "^3.0.10",
-    "reselect": "^2.5.4"
+    "office-ui-fabric-react": "^4.12.0"
   },
   "devDependencies": {
     "autoprefixer": "7.1.0",

--- a/packages/dashboard-base/index.js
+++ b/packages/dashboard-base/index.js
@@ -1,5 +1,19 @@
 export { default as Dashboard } from "./src/dashboard"
 export * from "./src/plugins"
 
-// FIXME: remove this when we extract authentication to cloud project
-export { intercomSettings } from "./src/authentication"
+import store from "./src/store"
+import { login } from "./src/authentication"
+import { pushNotification, NotificationType } from "./src/notifications"
+
+export const Auth = {
+  login: function(endpoint, secret, userInfo) {
+    return store.dispatch(login(endpoint, secret, userInfo))
+  }
+}
+
+export const Notifications = {
+  Type: NotificationType,
+  push: function(type, message) {
+    return store.dispatch(pushNotification(type, message))
+  }
+}

--- a/packages/dashboard-base/package-lock.json
+++ b/packages/dashboard-base/package-lock.json
@@ -1,21 +1,6 @@
 {
 	"lockfileVersion": 1,
 	"dependencies": {
-		"@microsoft/load-themed-styles": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.4.0.tgz",
-			"integrity": "sha1-GDC9288QFxLKJgIX5Vq3RKUgQdw="
-		},
-		"@uifabric/styling": {
-			"version": "0.13.5",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.13.5.tgz",
-			"integrity": "sha512-/rtcST8IEaSqJ900AsG+LVUGD8sTjgzfYjOo4DcAYufmw3XQyTs8jdo09MbsGbPWH/g/ru/UEl00p7zEHYElJQ=="
-		},
-		"@uifabric/utilities": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-4.7.1.tgz",
-			"integrity": "sha512-ll0PVLwECrwP6UxCG5+SR6Tu6C+leYsofacR5Y4ufDME/lRxI/eEIIKIXxSNt0s3AHA4FB43SXrOH7jkrZ14uQ=="
-		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -25,18 +10,6 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-		},
-		"babel-runtime": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-			"integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-			"dependencies": {
-				"core-js": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
-				}
-			}
 		},
 		"base64-js": {
 			"version": "1.2.1",
@@ -143,11 +116,6 @@
 			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
 			"integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
 		},
-		"glamor": {
-			"version": "2.20.25",
-			"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.25.tgz",
-			"integrity": "sha1-cbhLgrZ6kyd3GsWd5T7pFdFIpKM="
-		},
 		"history": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/history/-/history-3.3.0.tgz",
@@ -167,6 +135,11 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
 			"integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+		},
+		"immutable": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+			"integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
 		},
 		"inherits": {
 			"version": "2.0.3",
@@ -198,15 +171,20 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
 		},
-		"js-cookie": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.4.tgz",
-			"integrity": "sha1-2k7FA4ZvFJ0WTPJfV57zEBUCXY0="
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash-es": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
 		},
 		"loose-envify": {
 			"version": "1.3.1",
@@ -248,11 +226,6 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"office-ui-fabric-react": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-4.17.1.tgz",
-			"integrity": "sha512-qvJ0EqAFI9TeMhONRPHAdFEzHMGm0Zl343ZRQMrh29BdRFLTS863nQPWx3I36F5KFC1JD+GJzZvpWL0EGjJLwg=="
-		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -272,6 +245,11 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s="
+		},
+		"react-redux": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
+			"integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo="
 		},
 		"react-router": {
 			"version": "3.0.5",
@@ -298,15 +276,25 @@
 			"resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
 			"integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
 		},
-		"regenerator-runtime": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+		"redux": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.1.tgz",
+			"integrity": "sha512-iEVTlORM5mv6xb3ZAOyrVehVUD+W87jdFAX6SYVgZh3/SQAWFSxTRJOqPWQdvo4VN4lJkNDvqKlBXBabsJTSkA=="
 		},
-		"rtl-css-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.1.1.tgz",
-			"integrity": "sha1-IZ0QchuARIRXcaA76i5cQ4eCECQ="
+		"redux-immutable": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-3.1.0.tgz",
+			"integrity": "sha1-yvvWhuBxEmERm5wolgk13EeknQo="
+		},
+		"redux-thunk": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+		},
+		"reselect": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz",
+			"integrity": "sha1-t9I/3wC4P6etAnlUb427vXZccEc="
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -328,10 +316,10 @@
 			"resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
 			"integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U="
 		},
-		"tslib": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-			"integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
+		"symbol-observable": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+			"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
 		},
 		"ua-parser-js": {
 			"version": "0.7.13",

--- a/packages/dashboard-base/package-lock.json
+++ b/packages/dashboard-base/package-lock.json
@@ -7,9 +7,9 @@
 			"integrity": "sha1-GDC9288QFxLKJgIX5Vq3RKUgQdw="
 		},
 		"@uifabric/styling": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.13.3.tgz",
-			"integrity": "sha512-Vrvj49kUqcNLS3IhqwZs+84Jm3yL3ujrgSUojnz7tE12Fx5ZQfXXI5qx9QdJsOJRNbHLl0ZmA0L0zJPa83CGLA=="
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.13.5.tgz",
+			"integrity": "sha512-/rtcST8IEaSqJ900AsG+LVUGD8sTjgzfYjOo4DcAYufmw3XQyTs8jdo09MbsGbPWH/g/ru/UEl00p7zEHYElJQ=="
 		},
 		"@uifabric/utilities": {
 			"version": "4.7.1",
@@ -17,9 +17,9 @@
 			"integrity": "sha512-ll0PVLwECrwP6UxCG5+SR6Tu6C+leYsofacR5Y4ufDME/lRxI/eEIIKIXxSNt0s3AHA4FB43SXrOH7jkrZ14uQ=="
 		},
 		"asap": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-			"integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"async": {
 			"version": "1.5.2",
@@ -249,9 +249,9 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"office-ui-fabric-react": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-4.17.0.tgz",
-			"integrity": "sha512-xk/9K3bmEL1cIHNp0ljVEgRlAsdkMaLTseY4beIveMWzfUrUOl4QV44qWNwnRv9BK0TnmBm35MZqIpeZvyYRtw=="
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-4.17.1.tgz",
+			"integrity": "sha512-qvJ0EqAFI9TeMhONRPHAdFEzHMGm0Zl343ZRQMrh29BdRFLTS863nQPWx3I36F5KFC1JD+GJzZvpWL0EGjJLwg=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -272,11 +272,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s="
-		},
-		"raven-js": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.16.1.tgz",
-			"integrity": "sha1-SquLp8V7wmFgTblwxBxJE3NAxFA="
 		},
 		"react-router": {
 			"version": "3.0.5",

--- a/packages/dashboard-base/package.json
+++ b/packages/dashboard-base/package.json
@@ -5,10 +5,13 @@
   "dependencies": {
     "brace": "^0.5.1",
     "faunadb": "1.1.1",
-    "js-cookie": "^2.1.3",
-    "office-ui-fabric-react": "^4.12.0",
+    "immutable": "^3.8.1",
     "react-router": "^3.0.0",
     "react-split-pane": "^0.1.57",
-    "superagent": "^1.8.2"
+    "react-redux": "^5.0.1",
+    "redux": "^3.6.0",
+    "redux-thunk": "^2.1.0",
+    "redux-immutable": "^3.0.10",
+    "reselect": "^2.5.4"
   }
 }

--- a/packages/dashboard-base/src/__tests__/__snapshots__/dashboard.js.snap
+++ b/packages/dashboard-base/src/__tests__/__snapshots__/dashboard.js.snap
@@ -68,7 +68,11 @@ exports[`Container Component displays the base layout 1`] = `
     </div>
   </Connect(ToggleRepl)>
   <Connect(NotificationBar) />
-  <Connect(LoginForm) />
+  <Outlet
+    name="@@dashboard/authentication"
+  >
+    <Connect(LoginForm) />
+  </Outlet>
   <Outlet
     name="@@dashboard/after-application-content"
   />
@@ -143,7 +147,11 @@ exports[`Container Component renders a smaller sidebar when using a server key 1
     </div>
   </Connect(ToggleRepl)>
   <Connect(NotificationBar) />
-  <Connect(LoginForm) />
+  <Outlet
+    name="@@dashboard/authentication"
+  >
+    <Connect(LoginForm) />
+  </Outlet>
   <Outlet
     name="@@dashboard/after-application-content"
   />

--- a/packages/dashboard-base/src/authentication/__tests__/derived-data.js
+++ b/packages/dashboard-base/src/authentication/__tests__/derived-data.js
@@ -1,6 +1,6 @@
 import Immutable from "immutable"
 
-import { faunaClient, intercomSettings } from "../"
+import { faunaClient, currentUser } from "../"
 
 describe("faunaClient", () => {
   it("returns fauna client for the logged in user", () => {
@@ -19,31 +19,14 @@ describe("faunaClient", () => {
   })
 })
 
-describe("intercomSettings", () => {
+describe("currentUser", () => {
   it("returns logged in user", () => {
-    const state = Immutable.fromJS({
-      currentUser: {
-        client: "mockedClient",
-        settings: {
-          intercom: {
-            "app_id": "123"
-          }
-        }
-      }
-    })
-
-    expect(intercomSettings(state).toJS()).toEqual({
-      "app_id": "123"
-    })
+    const state = Immutable.fromJS({ currentUser: "logged-in-user" })
+    expect(currentUser(state)).toEqual("logged-in-user")
   })
 
-  it("returns null when no logged in user", () => {
+  it("returns null if no logged in user", () => {
     const state = Immutable.fromJS({ currentUser: null })
-    expect(intercomSettings(state)).toBeNull()
-  })
-
-  it("returns null when no intercom settings available for current user", () => {
-    const state = Immutable.fromJS({ currentUser: { settings: {} } })
-    expect(intercomSettings(state)).toBeNull()
+    expect(currentUser(state)).toBeNull()
   })
 })

--- a/packages/dashboard-base/src/authentication/components/user-account.js
+++ b/packages/dashboard-base/src/authentication/components/user-account.js
@@ -11,6 +11,9 @@ export class UserAccount extends Component {
   constructor(props) {
     super(props)
     this.state = { showMenu: false }
+    this.showMenu = this.showMenu.bind(this)
+    this.hideMenu = this.hideMenu.bind(this)
+    this.logout = this.logout.bind(this)
   }
 
   showMenu(e) {
@@ -25,7 +28,7 @@ export class UserAccount extends Component {
   }
 
   logout() {
-    window.location = this.props.dispatch(logout())
+    this.props.dispatch(logout())
   }
 
   render() {
@@ -35,20 +38,20 @@ export class UserAccount extends Component {
         <IconButton
         iconProps={{ iconName: 'Contact' }}
         description="Log out"
-        onClick={this.showMenu.bind(this)} />
+        onClick={this.showMenu} />
 
       {menuVisible ?
         <ContextualMenu
           targetElement={target}
           shouldFocusOnMount={true}
-          onDismiss={this.hideMenu.bind(this)}
+          onDismiss={this.hideMenu}
           directionalHint={DirectionalHint.bottomCenter}
           items={[
             {
               key: "logout-btn",
               name: "Log out",
               icon: "OutOfOffice",
-              onClick: this.logout.bind(this)
+              onClick: this.logout
             }
           ]} /> : null
       }

--- a/packages/dashboard-base/src/authentication/derived-data.js
+++ b/packages/dashboard-base/src/authentication/derived-data.js
@@ -1,14 +1,4 @@
-import { Map } from "immutable"
 import { createSelector } from "reselect"
 
-const currentUser = state => state.get("currentUser") || Map()
-
-export const faunaClient = createSelector(
-  [currentUser],
-  user => user.get("client", null)
-)
-
-export const intercomSettings = createSelector(
-  [currentUser],
-  user => user.getIn(["settings", "intercom"], null)
-)
+export const currentUser = state => state.get("currentUser")
+export const faunaClient = createSelector([currentUser], user => user ? user.get("client", null) : null)

--- a/packages/dashboard-base/src/authentication/session.js
+++ b/packages/dashboard-base/src/authentication/session.js
@@ -1,95 +1,46 @@
-import Immutable, { Map } from "immutable"
-import request from "superagent"
-import Cookies from "js-cookie"
-import { parse as parseURL } from "url"
+import { Map } from "immutable"
 
 import FaunaClient from "../persistence/faunadb-wrapper"
 import SessionStorage from "../persistence/session-storage"
-
-const WEBSITE = (() => {
-  if (process.env.NODE_ENV !== "production") {
-    return "http://localhost:3000"
-  }
-
-  const url = parseURL(window.location.href)
-  const host = url.hostname.replace(/^\w+\./, "") // removes its subdomain
-  return `${url.protocol}//${host}`
-})()
+import { Events } from "../plugins"
 
 const LOGGED_IN_USER = "loggedInUser"
-const CLOUD_COOKIE = "dashboard"
-const AUTH_API_TIMEOUT = 5000
-const AUTH_API = `${WEBSITE}/dashboard/user_info`
 
 const Actions = {
   LOGIN: "@@authentication/LOGIN",
   LOGOUT: "@@authentication/LOGOUT"
 }
 
-export const login = (endpoint, secret, settings = Map()) => dispatch => {
+export const login = (endpoint, secret, userInfo = {}) => dispatch => {
   return FaunaClient.discoverKeyType(endpoint, secret).then(client => {
     SessionStorage.set(LOGGED_IN_USER, {
       endpoint,
       secret
     })
 
-    const user = Map({ endpoint, secret, settings, client })
+    const user = Map({
+      endpoint,
+      secret,
+      client
+    })
+
     dispatch({ type: Actions.LOGIN, user })
+    Events.fire("@@authentication/user-logged-in", userInfo)
     return user
   })
 }
 
 export const restoreUserSession = () => (dispatch) => {
   const savedUser = SessionStorage.get(LOGGED_IN_USER)
-  if (savedUser) return dispatch(login(savedUser.endpoint, savedUser.secret))
-  return Promise.resolve(null)
+  return savedUser ?
+    dispatch(login(savedUser.endpoint, savedUser.secret)) :
+    Promise.resolve(null)
 }
 
-export const loginWithCloud = () => (dispatch) => {
-  if (!Cookies.get(CLOUD_COOKIE))
-    return Promise.resolve(false)
-
-  return new Promise((resolve, reject) => {
-    request.get(AUTH_API)
-      .timeout(AUTH_API_TIMEOUT)
-      .withCredentials()
-      .end((error, res) => {
-        if (error || !res.ok || !res.body) {
-          reject("Cloud authentication request has failed.")
-          return
-        }
-
-        const websiteUser = Immutable.fromJS(res.body)
-        const user = dispatch(login(
-          websiteUser.get("endpoint"),
-          websiteUser.get("secret"),
-          Map.of(
-            "logoutUrl", `${WEBSITE}/logout`,
-            "paymentUrl", `${WEBSITE}/account/billing`,
-            "paymentSet", websiteUser.getIn(["flags", "paymentSet"], false),
-            "acceptedTos", websiteUser.getIn(["flags", "acceptedTos"], false),
-            "intercom", Map.of(
-              "app_id", websiteUser.getIn(["settings", "intercom", "appId"]),
-              "user_hash", websiteUser.getIn(["settings", "intercom", "userHash"]),
-              "user_id", websiteUser.get("userId"),
-              "email", websiteUser.get("email")
-            )
-          )
-        ))
-
-        resolve(user)
-      })
-  })
-}
-
-export const logout = () => (dispatch, getState) => {
-  const logoutUrl = getState().getIn(["currentUser", "settings", "logoutUrl"], "/")
-
-  Cookies.remove(CLOUD_COOKIE)
+export const logout = () => (dispatch) => {
   SessionStorage.clear()
   dispatch({ type: Actions.LOGOUT })
-
-  return logoutUrl
+  Events.fire("@@authentication/user-logged-out")
 }
 
 export const reduceUserSession = (state = null, action) => {

--- a/packages/dashboard-base/src/dashboard.js
+++ b/packages/dashboard-base/src/dashboard.js
@@ -6,7 +6,7 @@ import { Router, IndexRoute, Route, Redirect, Link, browserHistory } from "react
 import "./dashboard.css"
 import logo from "./logo.svg"
 import GetStarted from "./get-started"
-import { createReduxStore } from "./store"
+import reduxStore from "./store"
 import { updateSelectedResource } from "./router"
 import { ActivityMonitor, monitorActivity } from "./activity-monitor"
 import { NotificationBar, watchForError } from "./notifications"
@@ -78,7 +78,9 @@ export class Container extends Component {
           </div>
         </ToggleRepl>
         <NotificationBar />
-        <LoginForm />
+        <Outlet name="@@dashboard/authentication">
+          <LoginForm />
+        </Outlet>
         <Outlet name="@@dashboard/after-application-content" />
       </div>
   }
@@ -119,7 +121,6 @@ export default class Dashboard extends Component {
 
   constructor(props) {
     super(props)
-    this.store = createReduxStore()
     this.firePageChanged = this.firePageChanged.bind(this)
   }
 
@@ -131,29 +132,32 @@ export default class Dashboard extends Component {
 
   render() {
     return <div>
-        <Provider store={this.store}>
-          <Router onUpdate={this.firePageChanged} history={browserHistory}>
-            <Redirect from="/" to="/db" />
-            <Route path="/db" component={Dashboard.Container}>
-              <Route path="indexes/:indexName" component={IndexManager} />
-              <Route path="indexes" component={IndexForm} />
-              <Route path="classes/:className" component={ClassManager} />
-              <Route path="classes" component={ClassForm} />
-              <Route path="databases" component={DatabaseForm} />
-              <Route path="keys" component={KeysManager} />
-              <Route path="**/indexes/:indexName" component={IndexManager} />
-              <Route path="**/indexes" component={IndexForm} />
-              <Route path="**/classes/:className" component={ClassManager} />
-              <Route path="**/classes" component={ClassForm} />
-              <Route path="**/databases" component={DatabaseForm} />
-              <Route path="**/keys" component={KeysManager} />
-              <IndexRoute component={GetStarted} />
-            </Route>
-            <Route path="*" component={Dashboard.NotFound} />
-          </Router>
-        </Provider>
-        {/* Entrypoint for rendering external plugins */}
-        { this.props.children }
-      </div>
+      {/* Entrypoint for rendering external plugins.
+        * This must be the first call to ensure plugins are declared before their outlets
+        * so that their outlets are able to render default content if no plugin was declared.
+        */}
+      { this.props.children }
+      <Provider store={reduxStore}>
+        <Router onUpdate={this.firePageChanged} history={browserHistory}>
+          <Redirect from="/" to="/db" />
+          <Route path="/db" component={Dashboard.Container}>
+            <Route path="indexes/:indexName" component={IndexManager} />
+            <Route path="indexes" component={IndexForm} />
+            <Route path="classes/:className" component={ClassManager} />
+            <Route path="classes" component={ClassForm} />
+            <Route path="databases" component={DatabaseForm} />
+            <Route path="keys" component={KeysManager} />
+            <Route path="**/indexes/:indexName" component={IndexManager} />
+            <Route path="**/indexes" component={IndexForm} />
+            <Route path="**/classes/:className" component={ClassManager} />
+            <Route path="**/classes" component={ClassForm} />
+            <Route path="**/databases" component={DatabaseForm} />
+            <Route path="**/keys" component={KeysManager} />
+            <IndexRoute component={GetStarted} />
+          </Route>
+          <Route path="*" component={Dashboard.NotFound} />
+        </Router>
+      </Provider>
+    </div>
   }
 }

--- a/packages/dashboard-base/src/plugins/components/__tests__/__snapshots__/plugin.js.snap
+++ b/packages/dashboard-base/src/plugins/components/__tests__/__snapshots__/plugin.js.snap
@@ -10,7 +10,7 @@ exports[`should render a plugin 2`] = `null`;
 
 exports[`should render a plugin 3`] = `
 <h1>
-  Default content
+  I will appear at "plugin-goes-here"
 </h1>
 `;
 

--- a/packages/dashboard-base/src/plugins/components/__tests__/__snapshots__/plugin.js.snap
+++ b/packages/dashboard-base/src/plugins/components/__tests__/__snapshots__/plugin.js.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render a plugin 1`] = `null`;
+exports[`should render a plugin 1`] = `
+<h1>
+  Default content
+</h1>
+`;
 
 exports[`should render a plugin 2`] = `null`;
 
 exports[`should render a plugin 3`] = `
-<div>
-  <h1>
-    I will appear at "plugin-goes-here"
-  </h1>
-</div>
+<h1>
+  Default content
+</h1>
 `;
+
+exports[`should render an empty outlet if no default content 1`] = `null`;

--- a/packages/dashboard-base/src/plugins/components/__tests__/plugin.js
+++ b/packages/dashboard-base/src/plugins/components/__tests__/plugin.js
@@ -24,6 +24,6 @@ it("should render a plugin", () => {
 })
 
 it("should render an empty outlet if no default content", () => {
-  const comp = shallow(<Outlet name="plugin-goes-here" />)
+  const comp = shallow(<Outlet name="empty-outlet" />)
   expect(shallowToJson(comp)).toMatchSnapshot()
 })

--- a/packages/dashboard-base/src/plugins/components/__tests__/plugin.js
+++ b/packages/dashboard-base/src/plugins/components/__tests__/plugin.js
@@ -5,7 +5,11 @@ import { shallowToJson } from "enzyme-to-json"
 import { Outlet, Plugin } from "../plugin"
 
 it("should render a plugin", () => {
-  const comp = shallow(<Outlet name="plugin-goes-here" />)
+  const comp = shallow(
+    <Outlet name="plugin-goes-here">
+      <h1>Default content</h1>
+    </Outlet>
+  )
   expect(shallowToJson(comp)).toMatchSnapshot()
 
   const plugin = shallow(
@@ -16,5 +20,10 @@ it("should render a plugin", () => {
 
   comp.update() // Force test wrapper to fetch plugin changes on the outlet component
   expect(shallowToJson(plugin)).toMatchSnapshot()
+  expect(shallowToJson(comp)).toMatchSnapshot()
+})
+
+it("should render an empty outlet if no default content", () => {
+  const comp = shallow(<Outlet name="plugin-goes-here" />)
   expect(shallowToJson(comp)).toMatchSnapshot()
 })

--- a/packages/dashboard-base/src/plugins/components/plugin.js
+++ b/packages/dashboard-base/src/plugins/components/plugin.js
@@ -1,37 +1,49 @@
-import React, { Component } from "react"
+import { Component } from "react"
 
 const outletsByName = {}
-const pluginsByOutlet = {}
+const pluginByOutlet = {}
 
 export class Outlet extends Component {
   constructor(props) {
     super(props)
     if (!props.name) throw new Error("Outlet must have a name")
-    outletsByName[props.name] = this
+  }
+
+  componentWillMount() {
+    outletsByName[this.props.name] = this
+  }
+
+  componentWillUnmount() {
+    delete outletsByName[this.props.name]
   }
 
   render() {
-    const plugins = Object.values(pluginsByOutlet[this.props.name] || {})
-    return plugins.length > 0 ? <div>{plugins.map(p => p.contents())}</div> : null
+    const plugin = pluginByOutlet[this.props.name]
+    return plugin ? plugin.content() : this.props.children || null
   }
 }
 
 export class Plugin extends Component {
   constructor(props) {
     super(props)
-    if (!props.name || !props.outlet) throw new Error("Plugin must have name and outlet")
-    pluginsByOutlet[props.outlet] = Object.assign(pluginsByOutlet[props.outlet] || {}, {
-      [props.name]: this
-    })
+    if (!props.outlet) throw new Error("Plugin must have an outlet")
   }
 
-  contents() {
+  componentWillMount() {
+    pluginByOutlet[this.props.outlet] = this
+  }
+
+  componentWillUnmount() {
+    delete pluginByOutlet[this.props.outlet]
+  }
+
+  content() {
     return this.props.children
   }
 
   render() {
     const outlet = outletsByName[this.props.outlet]
     if (outlet) outlet.forceUpdate()
-    return false
+    return null
   }
 }

--- a/packages/dashboard-base/src/store.js
+++ b/packages/dashboard-base/src/store.js
@@ -10,7 +10,7 @@ import { reduceNotifications } from "./notifications"
 import { reduceActivityMonitor } from "./activity-monitor"
 import { reduceUserSession } from "./authentication"
 
-export const createReduxStore = () => {
+export default (() => {
   const middlewares = [thunk]
 
   if (process.env.NODE_ENV === "development") {
@@ -43,4 +43,4 @@ export const createReduxStore = () => {
       applyMiddleware(...middlewares)
     )
   )
-}
+})()

--- a/packages/dashboard-cloud/package-lock.json
+++ b/packages/dashboard-cloud/package-lock.json
@@ -41,6 +41,11 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
 		},
+		"js-cookie": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.4.tgz",
+			"integrity": "sha1-2k7FA4ZvFJ0WTPJfV57zEBUCXY0="
+		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/packages/dashboard-cloud/package-lock.json
+++ b/packages/dashboard-cloud/package-lock.json
@@ -2,9 +2,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"asap": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-			"integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"core-js": {
 			"version": "1.2.7",

--- a/packages/dashboard-cloud/package.json
+++ b/packages/dashboard-cloud/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "dashboard-base": "1.0.0",
     "react-ga": "^2.1.2",
-    "raven-js": "^3.14.0"
+    "raven-js": "^3.14.0",
+    "js-cookie": "^2.1.3"
   }
 }

--- a/packages/dashboard-cloud/src/authentication/auto-login.js
+++ b/packages/dashboard-cloud/src/authentication/auto-login.js
@@ -1,0 +1,75 @@
+import React, { Component } from "react"
+import { parse as parseURL } from "url"
+import { Dialog, DialogType } from "office-ui-fabric-react/lib/Dialog"
+import { Spinner, SpinnerType } from "office-ui-fabric-react/lib/Spinner"
+import { Events, Auth, Notifications } from "dashboard-base"
+
+import { identifyCloudUser, logoutCloudUser } from "./cloud-login"
+
+const WEBSITE = (() => {
+  if (process.env.NODE_ENV !== "production") return "http://localhost:3000"
+  const url = parseURL(window.location.href)
+  const host = url.hostname.replace(/^\w+\./, "") // removes its subdomain
+  return `${url.protocol}//${host}`
+})()
+
+export default class AutoCloudLogin extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { message: "Logging in..." }
+  }
+
+  componentDidMount() {
+    Events.listen("@@authentication/user-logged-out", () => {
+      this.setState({ message: "Logging out..." }, () => {
+        logoutCloudUser()
+        window.location = `${WEBSITE}/logout`
+      })
+    })
+
+    identifyCloudUser(WEBSITE)
+      .then(user => user ? this.loginWithUser(user) : window.location = `${WEBSITE}/dashboard`)
+      .catch(this.notifyError)
+  }
+
+  loginWithUser(user) {
+    Auth
+      .login(user.endpoint, user.secret, user)
+      .then(() => {
+        this.setState({ message: null })
+        this.askForPaymentInfoIfNeeded(user)
+      })
+  }
+
+  notifyError(err) {
+    Notifications.push(Notifications.Type.ERROR, `${err.message}. You'll be redirected to ${WEBSITE} in 5 seconds...`)
+    setTimeout(() => window.location = WEBSITE, 5000)
+  }
+
+  askForPaymentInfoIfNeeded(user) {
+    if (this.shouldAskForPaymentInfo(user)) {
+      Notifications.push(Notifications.Type.WARNING,
+        <span>
+          Don't forget to <a href={`${WEBSITE}/account/billing`} target="_blank" rel="noopener noreferrer">setup your billing</a> information
+          to keep using FaunaDB
+        </span>
+      )
+    }
+  }
+
+  shouldAskForPaymentInfo(user) {
+    return user && user.flags &&
+      user.flags.acceptedTos === true &&
+      user.flags.paymentSet === false
+  }
+
+  render() {
+    return <Dialog
+        hidden={!this.state.message}
+        dialogContentProps={{ type: DialogType.largeHeader }}
+        modalProps={{ isBlocking: true }}
+        title="Connect to FaunaDB">
+        <Spinner type={SpinnerType.large} label={this.state.message} />
+      </Dialog>
+  }
+}

--- a/packages/dashboard-cloud/src/authentication/cloud-login.js
+++ b/packages/dashboard-cloud/src/authentication/cloud-login.js
@@ -1,0 +1,25 @@
+import Cookies from "js-cookie"
+
+const CLOUD_COOKIE = "dashboard"
+const AUTH_API_TIMEOUT = 60000
+
+const parseResponse = (res) => {
+  if (!res.ok) {
+    throw new Error(
+      "Unexpected error while logging into FaunaDB Cloud. " +
+      "Try again or check our status page: https://fauna.com/status")
+  }
+
+  return res.json()
+}
+
+export const logoutCloudUser = () => Cookies.remove(CLOUD_COOKIE)
+
+export const identifyCloudUser = (websiteUrl) => {
+  return !Cookies.get(CLOUD_COOKIE) ?
+    Promise.resolve(false) :
+    Promise.race([
+      new Promise((resolve, reject) => setTimeout(reject, AUTH_API_TIMEOUT, "Request timeout")),
+      fetch(`${websiteUrl}/dashboard/user_info`, { credentials: "include" }).then(parseResponse)
+    ])
+}

--- a/packages/dashboard-cloud/src/authentication/index.js
+++ b/packages/dashboard-cloud/src/authentication/index.js
@@ -1,0 +1,1 @@
+export { default as AutoCloudLogin } from "./auto-login"

--- a/packages/dashboard-cloud/src/index.js
+++ b/packages/dashboard-cloud/src/index.js
@@ -22,7 +22,7 @@ class CloudDashboard extends React.Component {
 
   render() {
     return <Dashboard>
-        <Plugin name="intercom" outlet="@@dashboard/after-application-content">
+        <Plugin outlet="@@dashboard/after-application-content">
           <IntercomWidget />
         </Plugin>
       </Dashboard>

--- a/packages/dashboard-cloud/src/index.js
+++ b/packages/dashboard-cloud/src/index.js
@@ -4,6 +4,7 @@ import ReactGA from "react-ga"
 import Raven from "raven-js"
 import { Dashboard, Plugin } from "dashboard-base"
 
+import { AutoCloudLogin } from "./authentication"
 import { IntercomWidget } from "./intercom"
 
 const isProduction = process.env.NODE_ENV === "production"
@@ -22,6 +23,9 @@ class CloudDashboard extends React.Component {
 
   render() {
     return <Dashboard>
+        <Plugin outlet="@@dashboard/authentication">
+          <AutoCloudLogin />
+        </Plugin>
         <Plugin outlet="@@dashboard/after-application-content">
           <IntercomWidget />
         </Plugin>


### PR DESCRIPTION
This quite changes the original behaviour as such:

**Base dashboard**:
- Check for credentials in the session store
- If has credentials, skip the login form
- If no credentials, request endpoint and password and save them into the session store

**Cloud Dashboard**:
- Check if there is a website cookie with an auth key
- If have the cookie, calls website API to validate the user
- If has no cookie, redirect user to website login

_Cloud dashboard will never show the login form._