### PR TITLE
Do not try to read data field from null results

### DIFF
--- a/packages/dashboard-base/src/dataset/components/query-result.js
+++ b/packages/dashboard-base/src/dataset/components/query-result.js
@@ -55,7 +55,8 @@ export default class QueryResult extends Component {
     const columnsByName = {}
     const data = []
 
-    const dataToParse = this.props.result.data || this.props.result
+    const result = this.props.result
+    const dataToParse = (result && result.data) || result
     let hasNonObjects = false
 
     if (Array.isArray(dataToParse)) {


### PR DESCRIPTION
It fixes an error when a query returns a null element. For example: `q.Select(0, [], null)`.