### PR TITLE
Make notification interface expose the timeout parameter

### DIFF
--- a/packages/dashboard-base/index.js
+++ b/packages/dashboard-base/index.js
@@ -13,7 +13,7 @@ export const Auth = {
 
 export const Notifications = {
   Type: NotificationType,
-  push: function(type, message) {
-    return store.dispatch(pushNotification(type, message))
+  push: function(type, message, timeout) {
+    return store.dispatch(pushNotification(type, message, timeout))
   }
 }

--- a/packages/dashboard-base/src/notifications/__tests__/notification-center.js
+++ b/packages/dashboard-base/src/notifications/__tests__/notification-center.js
@@ -34,6 +34,12 @@ describe("Given a notification store", () => {
     expect(notifications.length).toEqual(0)
   })
 
+  it("support infinity notifications", () => {
+    store.dispatch(pushNotification(NotificationType.SUCCESS, "Uhull!!", Infinity))
+    jest.runAllTimers()
+    expect(notifications.length).toEqual(1)
+  })
+
   it("should notify on success", () => {
     return store.dispatch(notify("Uhull!", successfull)).then(finalResult => {
       expect(notifications).toEqual([{ type: "success", message: "Uhull!" }])

--- a/packages/dashboard-base/src/notifications/notification-center.js
+++ b/packages/dashboard-base/src/notifications/notification-center.js
@@ -14,21 +14,19 @@ const Actions = {
   REMOVE: "@@notifications/REMOVE"
 }
 
-export const pushNotification = (type, message, timeoutTime) => (dispatch) => {
+export const pushNotification = (type, message, timeout = DEFAULT_NOTIFICATION_TIMEOUT) => (dispatch) => {
   const notification = Map.of("type", type, "message", message)
   dispatch({ type: Actions.PUSH, notification })
   Events.fire("@@notifications/pushed", { type, message })
-  if (typeof timeoutTime === "undefined") {
-    timeoutTime = DEFAULT_NOTIFICATION_TIMEOUT;
-  }
-  if (timeoutTime !== 0) {
+
+  if (timeout !== Infinity) {
     setTimeout(
       () => dispatch({
         type: Actions.REMOVE,
         notification
       }),
-      timeoutTime
-    )  
+      timeout
+    )
   }
 }
 


### PR DESCRIPTION
The original implementation don't account for the interface between the base dashboard and the cloud dashboard.