### PR TITLE
DT-30: Make npm scripts compatible with windows

### DIFF
--- a/config/select-package.js
+++ b/config/select-package.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const packageParam = '--package=';
+
+function findPackageParam(args, callback) {
+  var idx = null;
+  for (var i = 0; i < args.length; i++) {
+    if (args[i].indexOf(packageParam) === 0) {
+      idx = i;
+      break;
+    }
+  }
+
+  if (idx !== null) {
+    callback(args[idx].replace(packageParam, ''), idx);
+  }
+}
+
+module.exports = findPackageParam;

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/lerna bootstrap",
-    "start": "PACKAGE=packages/dashboard-base node scripts/start.js",
-    "test": "PACKAGE=packages/dashboard-base node scripts/test.js --env=jsdom",
-    "start-cloud": "PACKAGE=packages/dashboard-cloud node scripts/start.js",
-    "build-cloud": "PACKAGE=packages/dashboard-cloud node scripts/build.js",
-    "start-enterprise": "PACKAGE=packages/dashboard-enterprise node scripts/start.js",
-    "build-enterprise": "PACKAGE=packages/dashboard-enterprise node scripts/build.js"
+    "start": "node scripts/start.js --package=packages/dashboard-base",
+    "test": "node scripts/test.js --package=packages/dashboard-base --env=jsdom",
+    "start-cloud": "node scripts/start.js --package=packages/dashboard-cloud",
+    "build-cloud": "node scripts/build.js --package=packages/dashboard-cloud",
+    "start-enterprise": "node scripts/start.js --package=packages/dashboard-enterprise",
+    "build-enterprise": "node scripts/build.js --package=packages/dashboard-enterprise"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Select package to build
+require('../config/select-package')(process.argv.slice(2), function(pkg) {
+  process.env.PACKAGE = pkg;
+});
+
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Select package to build
+require('../config/select-package')(process.argv.slice(2), function(pkg) {
+  process.env.PACKAGE = pkg;
+});
+
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'development';
 process.env.NODE_ENV = 'development';

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,5 +1,13 @@
 'use strict';
 
+const argv = process.argv.slice(2);
+
+// Select package to build
+require('../config/select-package')(argv, function(pkg, idx) {
+  process.env.PACKAGE = pkg;
+  argv.splice(idx, 1);
+});
+
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'test';
 process.env.NODE_ENV = 'test';
@@ -17,7 +25,6 @@ require('../config/node-path').includeAllPackages();
 require('../config/env');
 
 const jest = require('jest');
-const argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {


### PR DESCRIPTION
Fixes #254 

Essentially, we can't set environment variables inline as we do in unix. I'm turning them into arguments for the project scripts.