### PR TITLE
keep client connection data out of the event bus

### DIFF
--- a/packages/dashboard-base/src/authentication/session.js
+++ b/packages/dashboard-base/src/authentication/session.js
@@ -25,7 +25,12 @@ export const login = (endpoint, secret, userInfo = {}) => dispatch => {
     })
 
     dispatch({ type: Actions.LOGIN, user })
-    Events.fire("@@authentication/user-logged-in", userInfo)
+    Events.fire("@@authentication/user-logged-in", {
+      email : userInfo.email,
+      userId : userInfo.userId,
+      settings : userInfo.settings,
+      flags : userInfo.flags
+    })
     return user
   })
 }


### PR DESCRIPTION
We don't know what will subscribe to these events (including log tools) so we should remove the secret from the event call.