### PR TITLE
Don't attach STDIN/tty during test-nowatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: build
 
 test-nowatch: build
 # Set CI env to dummy value so watch is not enabled.
-	docker run -it --rm -e CI=dummy -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts faunadb-dashboard npm run test
+	docker run --rm -e CI=dummy -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts faunadb-dashboard npm run test
 
 release-cloud: test-nowatch
 	docker build -f Dockerfile.release --build-arg DASHBOARD_EDITION=cloud --build-arg DASHBOARD_REVISION=$(GIT_REVISION) -t $(ECR_REPO):$(TAG)-cloud .


### PR DESCRIPTION
CI doesn't have a tty available, so the tests fail to run in that environment. This fixes that.