### PR TITLE
Share node_modules between host and image in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM node:8-slim
 
-WORKDIR /usr/src/app
+ARG UID
+ARG GID
 
-COPY package.json package-lock.json lerna.json /usr/src/app/
-RUN npm install --unsafe-perm --quiet
+RUN groupmod -g $GID node && \
+    usermod -u $UID -g $GID node
+
+WORKDIR /usr/src/app
+USER node
 
 CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,18 @@ GIT_SHORT := $(shell git rev-parse --short=12 HEAD)
 all: run
 
 build:
-	docker build --pull -t faunadb-dashboard .
+	docker build --pull --build-arg UID=`id -u` --build-arg GID=`id -g` -t faunadb-dashboard .
+	docker run --rm -v "$(PWD):/usr/src/app" faunadb-dashboard npm install
 
 run: build
-# Mount folders individually to use docker image's node_modules.
-	docker run -it --rm -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts --net=host faunadb-dashboard
+	docker run -it --rm -v "$(PWD):/usr/src/app" --net=host faunadb-dashboard
 
 test: build
-	docker run -it --rm -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts faunadb-dashboard npm run test
+	docker run -it --rm -v "$(PWD):/usr/src/app" faunadb-dashboard npm run test
 
 test-nowatch: build
 # Set CI env to dummy value so watch is not enabled.
-	docker run --rm -e CI=dummy -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts faunadb-dashboard npm run test
+	docker run --rm -e CI=dummy -v "$(PWD):/usr/src/app" faunadb-dashboard npm run test
 
 release-cloud: test-nowatch
 	docker build --pull -f Dockerfile.release --build-arg EDITION=cloud --build-arg REVISION=$(GIT_REVISION) -t $(ECR_REPO):$(GIT_SHORT)-cloud -t $(ECR_REPO):$(TAG)-cloud .

--- a/docker/dashboard.sh
+++ b/docker/dashboard.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 envsubst '${DASHBOARD_SERVER_NAME}' < /etc/nginx/conf.d/dashboard.conf.template > /etc/nginx/conf.d/dashboard.conf
 if [[ "$DASHBOARD_PROTOCOL" == "https" ]]; then


### PR DESCRIPTION
Stops isolating the development container from the host machine's node_modules folders, while maintaining the host machine's privileges. Previously the isolation was keeping the main node_modules isolated, but not the ones for each package. There's no straightforward way to isolate those, so not isolating and instead making sure the docker container doesn't operate at elevated permissions, to allow proper linux development/interoperability.

Also touches up the dashboard release script with a `set -e`.