### PR TITLE
Use volumes for build dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ npm-debug.log
 *.swp
 Dockerfile
 Dockerfile.release
+docker-compose.yml
 Makefile
 .gitignore
 .travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
 FROM node:8-slim
 
 WORKDIR /usr/src/app
-
-COPY package.json package-lock.json lerna.json /usr/src/app/
-RUN npm install --unsafe-perm --quiet
-
-CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,17 @@ clean:
 
 build:
 	docker-compose build --pull dashboard
+	docker-compose run --rm dashboard npm install --unsafe-perm --quiet
 
 run: build
 	docker-compose run --rm dashboard
 
 test: build
-	docker-compose run --rm dashboard /bin/bash -c "npm install --unsafe-perm --quiet && npm run test"
+	docker-compose run --rm dashboard npm run test
 
 test-nowatch: build
 # Set CI env to dummy value so watch is not enabled.
-	docker-compose run --rm -e CI=dummy dashboard /bin/bash -c "npm install --unsafe-perm --quiet && npm run test"
+	docker-compose run --rm -e CI=dummy dashboard npm run test
 
 release-cloud: test-nowatch
 	docker build --pull -f Dockerfile.release --build-arg EDITION=cloud --build-arg REVISION=$(GIT_REVISION) -t $(ECR_REPO):$(GIT_SHORT)-cloud -t $(ECR_REPO):$(TAG)-cloud .

--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,21 @@ GIT_SHORT := $(shell git rev-parse --short=12 HEAD)
 
 all: run
 
+clean:
+	docker-compose rm -fv
+
 build:
-	docker build --pull -t faunadb-dashboard .
+	docker-compose build --pull dashboard
 
 run: build
-# Mount folders individually to use docker image's node_modules.
-	docker run -it --rm -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts --net=host faunadb-dashboard
+	docker-compose run --rm dashboard
 
 test: build
-	docker run -it --rm -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts faunadb-dashboard npm run test
+	docker-compose run --rm dashboard /bin/bash -c "npm install --unsafe-perm --quiet && npm run test"
 
 test-nowatch: build
 # Set CI env to dummy value so watch is not enabled.
-	docker run --rm -e CI=dummy -v "$(PWD)/config":/usr/src/app/config -v "$(PWD)/packages":/usr/src/app/packages -v "$(PWD)/public":/usr/src/app/public -v "$(PWD)/scripts":/usr/src/app/scripts faunadb-dashboard npm run test
+	docker-compose run --rm -e CI=dummy dashboard /bin/bash -c "npm install --unsafe-perm --quiet && npm run test"
 
 release-cloud: test-nowatch
 	docker build --pull -f Dockerfile.release --build-arg EDITION=cloud --build-arg REVISION=$(GIT_REVISION) -t $(ECR_REPO):$(GIT_SHORT)-cloud -t $(ECR_REPO):$(TAG)-cloud .

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TAG ?= latest
 ECR_REPO := 957571668058.dkr.ecr.us-west-2.amazonaws.com/dashboard
 GIT_REVISION := $(shell git rev-parse HEAD)
 GIT_SHORT := $(shell git rev-parse --short=12 HEAD)
+PARENT_DIR := $(shell basename $(shell pwd))
 
 .PHONY: all build run test test-nowatch release-cloud release-enterprise
 
@@ -10,6 +11,7 @@ all: run
 
 clean:
 	docker-compose rm -fv
+	docker volume rm -f $(PARENT_DIR)_root_modules $(PARENT_DIR)_base_modules $(PARENT_DIR)_cloud_modules $(PARENT_DIR)_enterprise_modules
 
 build:
 	docker-compose build --pull dashboard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   dashboard:
     build: .
-    command: /bin/bash -c "npm install --unsafe-perm --quiet && npm run start"
+    command: npm run start
     network_mode: host
     volumes:
       - .:/usr/src/app:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+---
+version: "3"
+services:
+  dashboard:
+    build: .
+    command: /bin/bash -c "npm install --unsafe-perm --quiet && npm run start"
+    network_mode: host
+    volumes:
+      - .:/usr/src/app
+      - root_modules:/usr/src/app/node_modules
+      - base_modules:/usr/src/app/packages/dashboard-base/node_modules
+      - cloud_modules:/usr/src/app/packages/dashboard-cloud/node_modules
+      - enterprise_modules:/usr/src/app/packages/dashboard-enterprise/node_modules
+
+volumes:
+  root_modules:
+  base_modules:
+  cloud_modules:
+  enterprise_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: /bin/bash -c "npm install --unsafe-perm --quiet && npm run start"
     network_mode: host
     volumes:
-      - .:/usr/src/app
+      - .:/usr/src/app:cached
       - root_modules:/usr/src/app/node_modules
       - base_modules:/usr/src/app/packages/dashboard-base/node_modules
       - cloud_modules:/usr/src/app/packages/dashboard-cloud/node_modules


### PR DESCRIPTION
Second attempt at fixing the host needing to run `npm install` before the docker image is used for development. This version uses `docker-compose` to configure and run the image, setting up volumes for the 4 `node_modules` folders, which will hold the build deps (running `make clean` will clean these up).

Supersedes https://github.com/fauna/dashboard/pull/265 (`set -e` will be a separate PR).