### PR TITLE
WEB-29: Allow changing the listening port in docker

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -28,6 +28,7 @@ COPY --from=dashboard-build \
     /var/www
 
 ENV DASHBOARD_SERVER_NAME=faunadb-dashboard \
+    DASHBOARD_PORT=80 \
     DASHBOARD_PROTOCOL=http
 
 LABEL dashboard.edition=$EDITION \

--- a/docker/dashboard.sh
+++ b/docker/dashboard.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-envsubst '${DASHBOARD_SERVER_NAME}' < /etc/nginx/conf.d/dashboard.conf.template > /etc/nginx/conf.d/dashboard.conf
+envsubst '${DASHBOARD_SERVER_NAME} ${DASHBOARD_PORT}' < /etc/nginx/conf.d/dashboard.conf.template > /etc/nginx/conf.d/dashboard.conf
 if [[ "$DASHBOARD_PROTOCOL" == "https" ]]; then
   sed -i 's/#ENFORCE_HTTPS: //g' /etc/nginx/conf.d/dashboard.conf
 fi

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen      0.0.0.0:80 default_server;
+    listen      0.0.0.0:${DASHBOARD_PORT} default_server;
     server_name ${DASHBOARD_SERVER_NAME};
     root        /var/www;
 


### PR DESCRIPTION
Needed for staging, as port 80 will already be in use.