### PR TITLE
Bg remove billing nag and broken links ndl 16

### DIFF
--- a/packages/dashboard-base/src/__tests__/__snapshots__/dashboard.js.snap
+++ b/packages/dashboard-base/src/__tests__/__snapshots__/dashboard.js.snap
@@ -34,29 +34,11 @@ exports[`Container Component displays the base layout 1`] = `
             </li>
             <li>
               <a
-                href="http://fauna.com/tutorials"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Tutorials
-              </a>
-            </li>
-            <li>
-              <a
                 href="http://fauna.com/documentation"
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 Documentation
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://fauna.com/resources#drivers"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Drivers
               </a>
             </li>
             <li>
@@ -113,29 +95,11 @@ exports[`Container Component renders a smaller sidebar when using a server key 1
             </li>
             <li>
               <a
-                href="http://fauna.com/tutorials"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Tutorials
-              </a>
-            </li>
-            <li>
-              <a
                 href="http://fauna.com/documentation"
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 Documentation
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://fauna.com/resources#drivers"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Drivers
               </a>
             </li>
             <li>

--- a/packages/dashboard-base/src/dashboard.js
+++ b/packages/dashboard-base/src/dashboard.js
@@ -67,9 +67,7 @@ export class Container extends Component {
               <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10">
                 <ul>
                   <li><ActivityMonitor /></li>
-                  <li><a href="http://fauna.com/tutorials" target="_blank" rel="noopener noreferrer">Tutorials</a></li>
                   <li><a href="http://fauna.com/documentation" target="_blank" rel="noopener noreferrer">Documentation</a></li>
-                  <li><a href="https://fauna.com/resources#drivers" target="_blank" rel="noopener noreferrer">Drivers</a></li>
                   <li><UserAccount /></li>
                 </ul>
               </div>

--- a/packages/dashboard-cloud/src/authentication/auto-login.js
+++ b/packages/dashboard-cloud/src/authentication/auto-login.js
@@ -37,30 +37,12 @@ export default class AutoCloudLogin extends Component {
       .login(user.endpoint, user.secret, user)
       .then(() => {
         this.setState({ message: null })
-        this.askForPaymentInfoIfNeeded(user)
       })
   }
 
   notifyError(err) {
     Notifications.push(Notifications.Type.ERROR, `${err.message}. You'll be redirected to ${WEBSITE} in 5 seconds...`)
     setTimeout(() => window.location = WEBSITE, 5000)
-  }
-
-  askForPaymentInfoIfNeeded(user) {
-    if (this.shouldAskForPaymentInfo(user)) {
-      Notifications.push(Notifications.Type.WARNING,
-        <span>
-          Don't forget to <a href={`${WEBSITE}/account/billing`} target="_blank" rel="noopener noreferrer">setup your billing</a> information
-          to keep using FaunaDB
-        </span>
-      , Infinity)
-    }
-  }
-
-  shouldAskForPaymentInfo(user) {
-    return user && user.flags &&
-      user.flags.acceptedTos === true &&
-      user.flags.paymentSet === false
   }
 
   render() {


### PR DESCRIPTION
# Resolves #NDL-16

## Description (what problem you're fixing)
The Application had a fixed billing notification on free trial user's dashboard which seems not to be user-friendly.
The dashboard had two broken links(Tutorials and Drivers) that were redirecting to the documentation page.

## Fix (what you did to fix it)
Refactored notification code from the auto-login users' code.
Refactored the two codes from the nav code.
Deleted the dashboard snapshot test file and then test the application

## How to test (describe how to test your PR)
Login to Jenkins, from the dashboard, navigate via **website** to **staging**. Click **Build with Parameters** link and set: action: **deploy**, branch: **master**, dashboardBranch: **bg-remove-billing-nag-and-broken-links-NDL-16** and then click **build** button. 
When it finishes building successfully, copy this link [dashboard staging](https://dashboard.website-master.staging.faunadb.net) on the browser to view the implementation.

Before:
<img width="1433" alt="screen shot 2018-05-21 at 22 49 34" src="https://user-images.githubusercontent.com/27198006/40326873-84d12ac6-5d49-11e8-9dc4-cf1d7219584d.png">

After:
<img width="1436" alt="screen shot 2018-05-21 at 22 49 01" src="https://user-images.githubusercontent.com/27198006/40326882-8afeb99a-5d49-11e8-9ed3-f5bee614a27f.png">

