### PR TITLE
Make dashboard navs consistent with other application navs

### DIFF
--- a/packages/dashboard-base/src/__tests__/__snapshots__/dashboard.js.snap
+++ b/packages/dashboard-base/src/__tests__/__snapshots__/dashboard.js.snap
@@ -9,42 +9,47 @@ exports[`Container Component displays the base layout 1`] = `
       className="ms-Grid"
     >
       <div
-        className="ms-Grid-row header"
+        className="header-nav"
       >
         <div
-          className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2"
+          className="ms-Grid-row header"
         >
-          <Link
-            onlyActiveOnIndex={false}
-            style={Object {}}
-            to="/"
+          <div
+            className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2"
           >
-            <img
-              alt="logo"
-              src="logo.svg"
-            />
-          </Link>
-        </div>
-        <div
-          className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10"
-        >
-          <ul>
-            <li>
-              <Connect(ActivityMonitor) />
-            </li>
-            <li>
-              <a
-                href="http://fauna.com/documentation"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Documentation
-              </a>
-            </li>
-            <li>
-              <Connect(UserAccount) />
-            </li>
-          </ul>
+            <Link
+              onlyActiveOnIndex={false}
+              style={Object {}}
+              to="/"
+            >
+              <img
+                alt="logo"
+                className="logo"
+                src="logo.svg"
+              />
+            </Link>
+          </div>
+          <div
+            className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10"
+          >
+            <ul>
+              <li>
+                <Connect(ActivityMonitor) />
+              </li>
+              <li>
+                <a
+                  href="http://fauna.com/documentation"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Documentation
+                </a>
+              </li>
+              <li>
+                <Connect(UserAccount) />
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
@@ -70,42 +75,47 @@ exports[`Container Component renders a smaller sidebar when using a server key 1
       className="ms-Grid"
     >
       <div
-        className="ms-Grid-row header"
+        className="header-nav"
       >
         <div
-          className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2"
+          className="ms-Grid-row header"
         >
-          <Link
-            onlyActiveOnIndex={false}
-            style={Object {}}
-            to="/"
+          <div
+            className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2"
           >
-            <img
-              alt="logo"
-              src="logo.svg"
-            />
-          </Link>
-        </div>
-        <div
-          className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10"
-        >
-          <ul>
-            <li>
-              <Connect(ActivityMonitor) />
-            </li>
-            <li>
-              <a
-                href="http://fauna.com/documentation"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Documentation
-              </a>
-            </li>
-            <li>
-              <Connect(UserAccount) />
-            </li>
-          </ul>
+            <Link
+              onlyActiveOnIndex={false}
+              style={Object {}}
+              to="/"
+            >
+              <img
+                alt="logo"
+                className="logo"
+                src="logo.svg"
+              />
+            </Link>
+          </div>
+          <div
+            className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10"
+          >
+            <ul>
+              <li>
+                <Connect(ActivityMonitor) />
+              </li>
+              <li>
+                <a
+                  href="http://fauna.com/documentation"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Documentation
+                </a>
+              </li>
+              <li>
+                <Connect(UserAccount) />
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/dashboard-base/src/dashboard.css
+++ b/packages/dashboard-base/src/dashboard.css
@@ -13,14 +13,24 @@ dl dd {
     margin: 0.1em 0 0 0;
 }
 
+.header-nav {
+    background-color: black;
+    margin: 0 -8px 0 -8px;
+}
+
 .header {
-    padding: 0.5em 0 0.5em 0;
+    padding: 1.85em 0.6em 0.5em 3em;
     background-color: black;
     color: white;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1060px;
+    height: 99px;
 }
 
 .header ul {
     float: right;
+    margin-top: 9px;
 }
 
 .header ul li {
@@ -43,4 +53,9 @@ dl dd {
 .header a {
     font-weight: bold;
     text-decoration: none;
+}
+
+.logo {
+    height: 50px;
+    width: 160px;
 }

--- a/packages/dashboard-base/src/dashboard.js
+++ b/packages/dashboard-base/src/dashboard.js
@@ -60,16 +60,18 @@ export class Container extends Component {
     return <div className="ms-Fabric ms-font-m">
         <ToggleRepl>
           <div className="ms-Grid">
-            <div className="ms-Grid-row header">
-              <div className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2">
-                <Link to="/"><img src={logo} alt="logo" /></Link>
-              </div>
-              <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10">
-                <ul>
-                  <li><ActivityMonitor /></li>
-                  <li><a href="http://fauna.com/documentation" target="_blank" rel="noopener noreferrer">Documentation</a></li>
-                  <li><UserAccount /></li>
-                </ul>
+            <div className="header-nav">
+              <div className="ms-Grid-row header">
+                <div className="ms-Grid-col ms-u-sm5 ms-u-md6 ms-u-lg3 ms-u-xl2">
+                  <Link to="/"><img src={logo} alt="logo" className="logo" /></Link>
+                </div>
+                <div className="ms-Grid-col ms-u-sm12 ms-u-md6 ms-u-lg9 ms-u-xl10">
+                  <ul>
+                    <li><ActivityMonitor /></li>
+                    <li><a href="http://fauna.com/documentation" target="_blank" rel="noopener noreferrer">Documentation</a></li>
+                    <li><UserAccount /></li>
+                  </ul>
+                </div>
               </div>
             </div>
             { this.props.faunaClient ? this.renderMainView() : null }


### PR DESCRIPTION
# Resolves #NDL-31

## Description (what problem you're fixing)
The dashboard nav width was not consistent with the documentation page nav width.
The dashboard fauna logo was bigger than logos in other application pages.

## Fix (what you did to fix it)
Decrease the width to match https://fauna.com/documentation
Decrease the size of the logo to match the size of the logo on https://fauna.com/documentation

## How to test (describe how to test your PR)
Login to Jenkins, from the dashboard, navigate via **website** to **staging**. Click **Build with Parameters** link and set: action: **deploy**, branch: **master**, dashboardBranch: **bg-make-account-and-dashboard-navs-consistent-NDL-31** and then click **build** button. 
When it finishes building successfully, copy this link [dashboard staging](https://dashboard.website-master.staging.faunadb.net/db) on the browser to view the implementation.

Before:
<img width="1440" alt="screen shot 2018-05-23 at 20 11 59" src="https://user-images.githubusercontent.com/27198006/40440082-a9df9ef6-5ec5-11e8-8f02-dfdf8528e1ba.png">


After:
<img width="1438" alt="screen shot 2018-05-23 at 20 12 14" src="https://user-images.githubusercontent.com/27198006/40440089-b2ce53a4-5ec5-11e8-8b34-ab60da2f9600.png">


