### PR TITLE
remove gtm tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-TGTQJ7M');</script>
-    <!-- End Google Tag Manager -->
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="%PUBLIC_URL%/fabric.min.css">
     <!--


### PR DESCRIPTION
We are not going to bother implementing GTM on the dashboard at this time since it's being completely replaced within the next 1-2 months. The old GA implementation should be sufficient.